### PR TITLE
feat: UDim2 property support and Rojo-free plugin build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robloxstudio-mcp",
-  "version": "1.7.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robloxstudio-mcp",
-      "version": "1.7.2",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
@@ -78,6 +78,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1876,6 +1877,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2046,6 +2048,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2395,6 +2398,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3040,6 +3044,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4185,6 +4190,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6302,6 +6308,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:plugin": "cd studio-plugin && rojo build default.project.json --output MCPPlugin.rbxmx",
+    "build:plugin": "node scripts/build-plugin.mjs",
     "build:all": "npm run build && npm run build:plugin",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Build MCPPlugin.rbxmx from plugin.server.luau without requiring Rojo.
+ * Usage: node scripts/build-plugin.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+const pluginDir = join(rootDir, 'studio-plugin');
+const sourcePath = join(pluginDir, 'plugin.server.luau');
+const outputPath = join(pluginDir, 'MCPPlugin.rbxmx');
+
+const source = readFileSync(sourcePath, 'utf8');
+
+// In XML CDATA, the only forbidden sequence is ]]>. Split so it becomes ]]]]><![CDATA[>
+const cdataContent = source.replace(/\]\]>/g, ']]]]><![CDATA[>');
+
+const rbxmx = `<?xml version="1.0" encoding="utf-8"?>
+<roblox version="4">
+  <Item class="Script" referent="0">
+    <Properties>
+      <string name="Name">MCPPlugin</string>
+      <token name="RunContext">0</token>
+      <string name="Source"><![CDATA[${cdataContent}]]></string>
+    </Properties>
+  </Item>
+</roblox>
+`;
+
+writeFileSync(outputPath, rbxmx, 'utf8');
+console.log('Built studio-plugin/MCPPlugin.rbxmx');

--- a/src/index.ts
+++ b/src/index.ts
@@ -595,8 +595,8 @@ class RobloxStudioMCPServer {
                 },
                 component: {
                   type: 'string',
-                  enum: ['X', 'Y', 'Z'],
-                  description: 'Specific component for Vector3/UDim2 properties'
+                  enum: ['X', 'Y', 'Z', 'XScale', 'XOffset', 'YScale', 'YOffset'],
+                  description: 'For Vector3: X, Y, Z. For UDim2: XScale, XOffset, YScale, YOffset (value must be a number)'
                 }
               },
               required: ['paths', 'propertyName', 'operation', 'value']

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -389,7 +389,7 @@ export class RobloxStudioTools {
     propertyName: string, 
     operation: 'add' | 'multiply' | 'divide' | 'subtract' | 'power',
     value: any,
-    component?: 'X' | 'Y' | 'Z' // For Vector3/UDim2 properties
+    component?: 'X' | 'Y' | 'Z' | 'XScale' | 'XOffset' | 'YScale' | 'YOffset' // Vector3: X,Y,Z; UDim2: XScale, XOffset, YScale, YOffset
   ) {
     if (!paths || paths.length === 0 || !propertyName || !operation || value === undefined) {
       throw new Error('Paths, property name, operation, and value are required for set_relative_property');

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <roblox version="4">
   <Item class="Script" referent="0">
     <Properties>
@@ -556,6 +557,28 @@ local function convertPropertyValue(instance, propertyName, propertyValue)
 		return Color3.new(propertyValue.R or 0, propertyValue.G or 0, propertyValue.B or 0)
 	end
 
+	-- Handle UDim2: { X = { Scale, Offset }, Y = { Scale, Offset } } or array [scaleX, offsetX, scaleY, offsetY]
+	if type(propertyValue) == "table" then
+		if type(propertyValue.X) == "table" and type(propertyValue.Y) == "table" then
+			local xScale = (propertyValue.X.Scale ~= nil) and propertyValue.X.Scale or 0
+			local xOffset = (propertyValue.X.Offset ~= nil) and propertyValue.X.Offset or 0
+			local yScale = (propertyValue.Y.Scale ~= nil) and propertyValue.Y.Scale or 0
+			local yOffset = (propertyValue.Y.Offset ~= nil) and propertyValue.Y.Offset or 0
+			return UDim2.new(xScale, xOffset, yScale, yOffset)
+		end
+		if #propertyValue == 4 then
+			local success, currentVal = pcall(function() return instance[propertyName] end)
+			if success and typeof(currentVal) == "UDim2" then
+				return UDim2.new(
+					propertyValue[1] or 0,
+					propertyValue[2] or 0,
+					propertyValue[3] or 0,
+					propertyValue[4] or 0
+				)
+			end
+		end
+	end
+
 	-- Handle Enum values (strings like "Ball", "Cylinder", etc.)
 	if type(propertyValue) == "string" then
 		local success, currentVal = pcall(function() return instance[propertyName] end)
@@ -1107,7 +1130,11 @@ handlers.getInstanceProperties = function(requestData)
 
 		for _, prop in ipairs(commonProps) do
 			local propSuccess, propValue = pcall(function()
-				return tostring(instance[prop])
+				local val = instance[prop]
+				if typeof(val) == "UDim2" then
+					return { X = { Scale = val.X.Scale, Offset = val.X.Offset }, Y = { Scale = val.Y.Scale, Offset = val.Y.Offset }, _type = "UDim2" }
+				end
+				return tostring(val)
 			end)
 			if propSuccess then
 				properties[prop] = propValue
@@ -2277,6 +2304,39 @@ handlers.setRelativeProperty = function(requestData)
 					elseif operation == "power" then
 						newValue = Vector3.new(x ^ value, y ^ value, z ^ value)
 					end
+				elseif typeof(currentValue) == "UDim2" and type(value) == "number" and component then
+					local xs, xo = currentValue.X.Scale, currentValue.X.Offset
+					local ys, yo = currentValue.Y.Scale, currentValue.Y.Offset
+					if component == "XScale" then
+						if operation == "add" then xs = xs + value
+						elseif operation == "subtract" then xs = xs - value
+						elseif operation == "multiply" then xs = xs * value
+						elseif operation == "divide" then xs = xs / value
+						elseif operation == "power" then xs = xs ^ value
+						end
+					elseif component == "XOffset" then
+						if operation == "add" then xo = xo + value
+						elseif operation == "subtract" then xo = xo - value
+						elseif operation == "multiply" then xo = xo * value
+						elseif operation == "divide" then xo = xo / value
+						elseif operation == "power" then xo = xo ^ value
+						end
+					elseif component == "YScale" then
+						if operation == "add" then ys = ys + value
+						elseif operation == "subtract" then ys = ys - value
+						elseif operation == "multiply" then ys = ys * value
+						elseif operation == "divide" then ys = ys / value
+						elseif operation == "power" then ys = ys ^ value
+						end
+					elseif component == "YOffset" then
+						if operation == "add" then yo = yo + value
+						elseif operation == "subtract" then yo = yo - value
+						elseif operation == "multiply" then yo = yo * value
+						elseif operation == "divide" then yo = yo / value
+						elseif operation == "power" then yo = yo ^ value
+						end
+					end
+					newValue = UDim2.new(xs, xo, ys, yo)
 				else
 					error("Unsupported property type or operation")
 				end

--- a/studio-plugin/plugin.server.luau
+++ b/studio-plugin/plugin.server.luau
@@ -551,6 +551,28 @@ local function convertPropertyValue(instance, propertyName, propertyValue)
 		return Color3.new(propertyValue.R or 0, propertyValue.G or 0, propertyValue.B or 0)
 	end
 
+	-- Handle UDim2: { X = { Scale, Offset }, Y = { Scale, Offset } } or array [scaleX, offsetX, scaleY, offsetY]
+	if type(propertyValue) == "table" then
+		if type(propertyValue.X) == "table" and type(propertyValue.Y) == "table" then
+			local xScale = (propertyValue.X.Scale ~= nil) and propertyValue.X.Scale or 0
+			local xOffset = (propertyValue.X.Offset ~= nil) and propertyValue.X.Offset or 0
+			local yScale = (propertyValue.Y.Scale ~= nil) and propertyValue.Y.Scale or 0
+			local yOffset = (propertyValue.Y.Offset ~= nil) and propertyValue.Y.Offset or 0
+			return UDim2.new(xScale, xOffset, yScale, yOffset)
+		end
+		if #propertyValue == 4 then
+			local success, currentVal = pcall(function() return instance[propertyName] end)
+			if success and typeof(currentVal) == "UDim2" then
+				return UDim2.new(
+					propertyValue[1] or 0,
+					propertyValue[2] or 0,
+					propertyValue[3] or 0,
+					propertyValue[4] or 0
+				)
+			end
+		end
+	end
+
 	-- Handle Enum values (strings like "Ball", "Cylinder", etc.)
 	if type(propertyValue) == "string" then
 		local success, currentVal = pcall(function() return instance[propertyName] end)
@@ -1102,7 +1124,11 @@ handlers.getInstanceProperties = function(requestData)
 
 		for _, prop in ipairs(commonProps) do
 			local propSuccess, propValue = pcall(function()
-				return tostring(instance[prop])
+				local val = instance[prop]
+				if typeof(val) == "UDim2" then
+					return { X = { Scale = val.X.Scale, Offset = val.X.Offset }, Y = { Scale = val.Y.Scale, Offset = val.Y.Offset }, _type = "UDim2" }
+				end
+				return tostring(val)
 			end)
 			if propSuccess then
 				properties[prop] = propValue
@@ -2272,6 +2298,39 @@ handlers.setRelativeProperty = function(requestData)
 					elseif operation == "power" then
 						newValue = Vector3.new(x ^ value, y ^ value, z ^ value)
 					end
+				elseif typeof(currentValue) == "UDim2" and type(value) == "number" and component then
+					local xs, xo = currentValue.X.Scale, currentValue.X.Offset
+					local ys, yo = currentValue.Y.Scale, currentValue.Y.Offset
+					if component == "XScale" then
+						if operation == "add" then xs = xs + value
+						elseif operation == "subtract" then xs = xs - value
+						elseif operation == "multiply" then xs = xs * value
+						elseif operation == "divide" then xs = xs / value
+						elseif operation == "power" then xs = xs ^ value
+						end
+					elseif component == "XOffset" then
+						if operation == "add" then xo = xo + value
+						elseif operation == "subtract" then xo = xo - value
+						elseif operation == "multiply" then xo = xo * value
+						elseif operation == "divide" then xo = xo / value
+						elseif operation == "power" then xo = xo ^ value
+						end
+					elseif component == "YScale" then
+						if operation == "add" then ys = ys + value
+						elseif operation == "subtract" then ys = ys - value
+						elseif operation == "multiply" then ys = ys * value
+						elseif operation == "divide" then ys = ys / value
+						elseif operation == "power" then ys = ys ^ value
+						end
+					elseif component == "YOffset" then
+						if operation == "add" then yo = yo + value
+						elseif operation == "subtract" then yo = yo - value
+						elseif operation == "multiply" then yo = yo * value
+						elseif operation == "divide" then yo = yo / value
+						elseif operation == "power" then yo = yo ^ value
+						end
+					end
+					newValue = UDim2.new(xs, xo, ys, yo)
 				else
 					error("Unsupported property type or operation")
 				end


### PR DESCRIPTION
**UDim2 support:** Edit UDim2 properties (Size, Position, etc.) via `set_property`, `set_relative_property`, and round-trip from `get_instance_properties`.

- set_property / create_object_with_properties: Accept UDim2 as `{ X: { Scale, Offset }, Y: { Scale, Offset } }` or `[scaleX, offsetX, scaleY, offsetY]`.
- set_relative_property: For UDim2, component can be XScale, XOffset, YScale, YOffset; value is a number.
- get_instance_properties: UDim2 properties returned as editable object form.
- MCP schema: set_relative_property component enum extended with XScale, XOffset, YScale, YOffset.

**Rojo-free plugin build:** Build MCPPlugin.rbxmx from plugin.server.luau using Node (scripts/build-plugin.mjs). package.json build:plugin runs `node scripts/build-plugin.mjs` instead of Rojo.

**Files:** studio-plugin/plugin.server.luau, studio-plugin/MCPPlugin.rbxmx, src/index.ts, src/tools/index.ts, scripts/build-plugin.mjs, package.json, package-lock.json.

This PR does not include the reconnection fix (PR 1). The two can be merged in any order.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full UDim2 property editing and round-trip support, and removes the Rojo requirement by building the plugin with Node. This improves property tooling and simplifies the build process.

- **New Features**
  - set_property and create_object_with_properties accept UDim2 as { X: { Scale, Offset }, Y: { Scale, Offset } } or [scaleX, offsetX, scaleY, offsetY].
  - set_relative_property supports UDim2 components: XScale, XOffset, YScale, YOffset (numeric operations).
  - get_instance_properties returns UDim2 (Size, Position, etc.) as an editable object for round-trip edits.
  - MCP schema and TypeScript enums extended with UDim2 components.

- **Dependencies**
  - Replace Rojo build with scripts/build-plugin.mjs to generate MCPPlugin.rbxmx from plugin.server.luau.
  - package.json build:plugin updated to run the Node script.

<sup>Written for commit bdc6b8ab7291c416d671ad06bb35255fc2ed0360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for UDim2 properties, including XScale, XOffset, YScale, and YOffset component manipulation.

* **Chores**
  * Updated the plugin build process to use a Node.js script for improved build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->