### PR TITLE
feat: UDim2 property support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -595,8 +595,8 @@ class RobloxStudioMCPServer {
                 },
                 component: {
                   type: 'string',
-                  enum: ['X', 'Y', 'Z'],
-                  description: 'Specific component for Vector3/UDim2 properties'
+                  enum: ['X', 'Y', 'Z', 'XScale', 'XOffset', 'YScale', 'YOffset'],
+                  description: 'For Vector3: X, Y, Z. For UDim2: XScale, XOffset, YScale, YOffset (value must be a number)'
                 }
               },
               required: ['paths', 'propertyName', 'operation', 'value']

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -389,7 +389,7 @@ export class RobloxStudioTools {
     propertyName: string, 
     operation: 'add' | 'multiply' | 'divide' | 'subtract' | 'power',
     value: any,
-    component?: 'X' | 'Y' | 'Z' // For Vector3/UDim2 properties
+    component?: 'X' | 'Y' | 'Z' | 'XScale' | 'XOffset' | 'YScale' | 'YOffset' // Vector3: X,Y,Z; UDim2: XScale, XOffset, YScale, YOffset
   ) {
     if (!paths || paths.length === 0 || !propertyName || !operation || value === undefined) {
       throw new Error('Paths, property name, operation, and value are required for set_relative_property');

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <roblox version="4">
   <Item class="Script" referent="0">
     <Properties>
@@ -556,6 +557,28 @@ local function convertPropertyValue(instance, propertyName, propertyValue)
 		return Color3.new(propertyValue.R or 0, propertyValue.G or 0, propertyValue.B or 0)
 	end
 
+	-- Handle UDim2: { X = { Scale, Offset }, Y = { Scale, Offset } } or array [scaleX, offsetX, scaleY, offsetY]
+	if type(propertyValue) == "table" then
+		if type(propertyValue.X) == "table" and type(propertyValue.Y) == "table" then
+			local xScale = (propertyValue.X.Scale ~= nil) and propertyValue.X.Scale or 0
+			local xOffset = (propertyValue.X.Offset ~= nil) and propertyValue.X.Offset or 0
+			local yScale = (propertyValue.Y.Scale ~= nil) and propertyValue.Y.Scale or 0
+			local yOffset = (propertyValue.Y.Offset ~= nil) and propertyValue.Y.Offset or 0
+			return UDim2.new(xScale, xOffset, yScale, yOffset)
+		end
+		if #propertyValue == 4 then
+			local success, currentVal = pcall(function() return instance[propertyName] end)
+			if success and typeof(currentVal) == "UDim2" then
+				return UDim2.new(
+					propertyValue[1] or 0,
+					propertyValue[2] or 0,
+					propertyValue[3] or 0,
+					propertyValue[4] or 0
+				)
+			end
+		end
+	end
+
 	-- Handle Enum values (strings like "Ball", "Cylinder", etc.)
 	if type(propertyValue) == "string" then
 		local success, currentVal = pcall(function() return instance[propertyName] end)
@@ -1107,7 +1130,11 @@ handlers.getInstanceProperties = function(requestData)
 
 		for _, prop in ipairs(commonProps) do
 			local propSuccess, propValue = pcall(function()
-				return tostring(instance[prop])
+				local val = instance[prop]
+				if typeof(val) == "UDim2" then
+					return { X = { Scale = val.X.Scale, Offset = val.X.Offset }, Y = { Scale = val.Y.Scale, Offset = val.Y.Offset }, _type = "UDim2" }
+				end
+				return tostring(val)
 			end)
 			if propSuccess then
 				properties[prop] = propValue
@@ -2277,6 +2304,39 @@ handlers.setRelativeProperty = function(requestData)
 					elseif operation == "power" then
 						newValue = Vector3.new(x ^ value, y ^ value, z ^ value)
 					end
+				elseif typeof(currentValue) == "UDim2" and type(value) == "number" and component then
+					local xs, xo = currentValue.X.Scale, currentValue.X.Offset
+					local ys, yo = currentValue.Y.Scale, currentValue.Y.Offset
+					if component == "XScale" then
+						if operation == "add" then xs = xs + value
+						elseif operation == "subtract" then xs = xs - value
+						elseif operation == "multiply" then xs = xs * value
+						elseif operation == "divide" then xs = xs / value
+						elseif operation == "power" then xs = xs ^ value
+						end
+					elseif component == "XOffset" then
+						if operation == "add" then xo = xo + value
+						elseif operation == "subtract" then xo = xo - value
+						elseif operation == "multiply" then xo = xo * value
+						elseif operation == "divide" then xo = xo / value
+						elseif operation == "power" then xo = xo ^ value
+						end
+					elseif component == "YScale" then
+						if operation == "add" then ys = ys + value
+						elseif operation == "subtract" then ys = ys - value
+						elseif operation == "multiply" then ys = ys * value
+						elseif operation == "divide" then ys = ys / value
+						elseif operation == "power" then ys = ys ^ value
+						end
+					elseif component == "YOffset" then
+						if operation == "add" then yo = yo + value
+						elseif operation == "subtract" then yo = yo - value
+						elseif operation == "multiply" then yo = yo * value
+						elseif operation == "divide" then yo = yo / value
+						elseif operation == "power" then yo = yo ^ value
+						end
+					end
+					newValue = UDim2.new(xs, xo, ys, yo)
 				else
 					error("Unsupported property type or operation")
 				end

--- a/studio-plugin/plugin.server.luau
+++ b/studio-plugin/plugin.server.luau
@@ -551,6 +551,28 @@ local function convertPropertyValue(instance, propertyName, propertyValue)
 		return Color3.new(propertyValue.R or 0, propertyValue.G or 0, propertyValue.B or 0)
 	end
 
+	-- Handle UDim2: { X = { Scale, Offset }, Y = { Scale, Offset } } or array [scaleX, offsetX, scaleY, offsetY]
+	if type(propertyValue) == "table" then
+		if type(propertyValue.X) == "table" and type(propertyValue.Y) == "table" then
+			local xScale = (propertyValue.X.Scale ~= nil) and propertyValue.X.Scale or 0
+			local xOffset = (propertyValue.X.Offset ~= nil) and propertyValue.X.Offset or 0
+			local yScale = (propertyValue.Y.Scale ~= nil) and propertyValue.Y.Scale or 0
+			local yOffset = (propertyValue.Y.Offset ~= nil) and propertyValue.Y.Offset or 0
+			return UDim2.new(xScale, xOffset, yScale, yOffset)
+		end
+		if #propertyValue == 4 then
+			local success, currentVal = pcall(function() return instance[propertyName] end)
+			if success and typeof(currentVal) == "UDim2" then
+				return UDim2.new(
+					propertyValue[1] or 0,
+					propertyValue[2] or 0,
+					propertyValue[3] or 0,
+					propertyValue[4] or 0
+				)
+			end
+		end
+	end
+
 	-- Handle Enum values (strings like "Ball", "Cylinder", etc.)
 	if type(propertyValue) == "string" then
 		local success, currentVal = pcall(function() return instance[propertyName] end)
@@ -1102,7 +1124,11 @@ handlers.getInstanceProperties = function(requestData)
 
 		for _, prop in ipairs(commonProps) do
 			local propSuccess, propValue = pcall(function()
-				return tostring(instance[prop])
+				local val = instance[prop]
+				if typeof(val) == "UDim2" then
+					return { X = { Scale = val.X.Scale, Offset = val.X.Offset }, Y = { Scale = val.Y.Scale, Offset = val.Y.Offset }, _type = "UDim2" }
+				end
+				return tostring(val)
 			end)
 			if propSuccess then
 				properties[prop] = propValue
@@ -2272,6 +2298,39 @@ handlers.setRelativeProperty = function(requestData)
 					elseif operation == "power" then
 						newValue = Vector3.new(x ^ value, y ^ value, z ^ value)
 					end
+				elseif typeof(currentValue) == "UDim2" and type(value) == "number" and component then
+					local xs, xo = currentValue.X.Scale, currentValue.X.Offset
+					local ys, yo = currentValue.Y.Scale, currentValue.Y.Offset
+					if component == "XScale" then
+						if operation == "add" then xs = xs + value
+						elseif operation == "subtract" then xs = xs - value
+						elseif operation == "multiply" then xs = xs * value
+						elseif operation == "divide" then xs = xs / value
+						elseif operation == "power" then xs = xs ^ value
+						end
+					elseif component == "XOffset" then
+						if operation == "add" then xo = xo + value
+						elseif operation == "subtract" then xo = xo - value
+						elseif operation == "multiply" then xo = xo * value
+						elseif operation == "divide" then xo = xo / value
+						elseif operation == "power" then xo = xo ^ value
+						end
+					elseif component == "YScale" then
+						if operation == "add" then ys = ys + value
+						elseif operation == "subtract" then ys = ys - value
+						elseif operation == "multiply" then ys = ys * value
+						elseif operation == "divide" then ys = ys / value
+						elseif operation == "power" then ys = ys ^ value
+						end
+					elseif component == "YOffset" then
+						if operation == "add" then yo = yo + value
+						elseif operation == "subtract" then yo = yo - value
+						elseif operation == "multiply" then yo = yo * value
+						elseif operation == "divide" then yo = yo / value
+						elseif operation == "power" then yo = yo ^ value
+						end
+					end
+					newValue = UDim2.new(xs, xo, ys, yo)
 				else
 					error("Unsupported property type or operation")
 				end


### PR DESCRIPTION
Adds support for editing UDim2 properties (Size, Position, etc.) via MCP tools.

**set_property / create_object_with_properties:** Accept UDim2 as object `{ X: { Scale, Offset }, Y: { Scale, Offset } }` or array `[scaleX, offsetX, scaleY, offsetY]`.

**set_relative_property:** For UDim2 properties, component can be XScale, XOffset, YScale, or YOffset; value is a number (add/multiply/divide/subtract/power).

**get_instance_properties:** UDim2 properties (e.g. Size, Position on GuiObjects) are returned as editable object form for round-trip editing.

**MCP schema:** set_relative_property component enum extended with XScale, XOffset, YScale, YOffset.

**Files:** studio-plugin/plugin.server.luau, studio-plugin/MCPPlugin.rbxmx, src/index.ts, src/tools/index.ts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full UDim2 support in MCP tools for editing GuiObject properties like Size and Position. Enables per-component relative operations and returns UDim2s in an editable form.

- **New Features**
  - set_property and create_object_with_properties accept UDim2 as { X: { Scale, Offset }, Y: { Scale, Offset } } or [scaleX, offsetX, scaleY, offsetY].
  - set_relative_property supports XScale, XOffset, YScale, YOffset with add/multiply/divide/subtract/power; schema and TypeScript enums updated.
  - get_instance_properties serializes UDim2 to { X: { Scale, Offset }, Y: { Scale, Offset }, _type: "UDim2" } for round‑trip editing.

<sup>Written for commit f62ef956c815a34402dfe349ec011796cd25171a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

