### PR TITLE
feat: Rojo-free plugin build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robloxstudio-mcp",
-  "version": "1.7.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robloxstudio-mcp",
-      "version": "1.7.2",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
@@ -78,6 +78,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1876,6 +1877,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2046,6 +2048,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2395,6 +2398,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3040,6 +3044,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4185,6 +4190,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6302,6 +6308,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "build:plugin": "cd studio-plugin && rojo build default.project.json --output MCPPlugin.rbxmx",
+    "build:plugin": "node scripts/build-plugin.mjs",
     "build:all": "npm run build && npm run build:plugin",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Build MCPPlugin.rbxmx from plugin.server.luau without requiring Rojo.
+ * Usage: node scripts/build-plugin.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+const pluginDir = join(rootDir, 'studio-plugin');
+const sourcePath = join(pluginDir, 'plugin.server.luau');
+const outputPath = join(pluginDir, 'MCPPlugin.rbxmx');
+
+const source = readFileSync(sourcePath, 'utf8');
+
+// In XML CDATA, the only forbidden sequence is ]]>. Split so it becomes ]]]]><![CDATA[>
+const cdataContent = source.replace(/\]\]>/g, ']]]]><![CDATA[>');
+
+const rbxmx = `<?xml version="1.0" encoding="utf-8"?>
+<roblox version="4">
+  <Item class="Script" referent="0">
+    <Properties>
+      <string name="Name">MCPPlugin</string>
+      <token name="RunContext">0</token>
+      <string name="Source"><![CDATA[${cdataContent}]]></string>
+    </Properties>
+  </Item>
+</roblox>
+`;
+
+writeFileSync(outputPath, rbxmx, 'utf8');
+console.log('Built studio-plugin/MCPPlugin.rbxmx');


### PR DESCRIPTION
Adds a Node-only build for the Studio plugin so Rojo is not required.

**scripts/build-plugin.mjs:** Reads studio-plugin/plugin.server.luau, wraps it in the Roblox XML format, writes studio-plugin/MCPPlugin.rbxmx. No Rojo dependency.

**package.json:** build:plugin runs `node scripts/build-plugin.mjs` instead of `rojo build`.

**Files:** scripts/build-plugin.mjs (new), package.json, package-lock.json.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the Studio plugin without Rojo by adding a Node script that generates MCPPlugin.rbxmx from plugin.server.luau. This simplifies local builds and CI by removing the Rojo dependency.

- **New Features**
  - Added scripts/build-plugin.mjs to wrap plugin.server.luau into Roblox XML (rbxmx) and write studio-plugin/MCPPlugin.rbxmx.
  - Updated package.json: build:plugin now runs node scripts/build-plugin.mjs.

- **Migration**
  - Use npm run build:plugin to generate studio-plugin/MCPPlugin.rbxmx.
  - Rojo is no longer required to build the plugin.

<sup>Written for commit 831bc242fb0ae1650563229e0aba3518f0e735af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

