### PR TITLE
fix: port retry crashes on EADDRINUSE instead of trying next port

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { createRequire } from 'module';
+import http from 'node:http';
 import { createHttpServer } from './http-server.js';
 import { RobloxStudioTools } from './tools/index.js';
 import { BridgeService } from './bridge-service.js';
@@ -1024,23 +1025,19 @@ class RobloxStudioMCPServer {
     const basePort = process.env.ROBLOX_STUDIO_PORT ? parseInt(process.env.ROBLOX_STUDIO_PORT) : 58741;
     const maxPort = basePort + 4;
     const host = process.env.ROBLOX_STUDIO_HOST || '0.0.0.0';
-    const httpServer = createHttpServer(this.tools, this.bridge);
+    const httpApp = createHttpServer(this.tools, this.bridge);
 
     let boundPort = 0;
     for (let port = basePort; port <= maxPort; port++) {
       try {
         await new Promise<void>((resolve, reject) => {
+          const server = http.createServer(httpApp);
           const onError = (err: NodeJS.ErrnoException) => {
-            if (err.code === 'EADDRINUSE') {
-              httpServer.removeListener('error', onError);
-              reject(err);
-            } else {
-              reject(err);
-            }
+            reject(err);
           };
-          httpServer.once('error', onError);
-          httpServer.listen(port, host, () => {
-            httpServer.removeListener('error', onError);
+          server.once('error', onError);
+          server.listen(port, host, () => {
+            server.removeListener('error', onError);
             boundPort = port;
             console.error(`HTTP server listening on ${host}:${port} for Studio plugin`);
             resolve();
@@ -1060,23 +1057,19 @@ class RobloxStudioMCPServer {
     }
 
     const LEGACY_PORT = 3002;
-    let legacyServer: ReturnType<typeof createHttpServer> | undefined;
+    let legacyApp: ReturnType<typeof createHttpServer> | undefined;
     if (boundPort !== LEGACY_PORT) {
       const legacy = createHttpServer(this.tools, this.bridge);
-      legacyServer = legacy;
+      legacyApp = legacy;
       try {
         await new Promise<void>((resolve, reject) => {
+          const server = http.createServer(legacy);
           const onError = (err: NodeJS.ErrnoException) => {
-            if (err.code === 'EADDRINUSE') {
-              legacy.removeListener('error', onError);
-              reject(err);
-            } else {
-              reject(err);
-            }
+            reject(err);
           };
-          legacy.once('error', onError);
-          legacy.listen(LEGACY_PORT, host, () => {
-            legacy.removeListener('error', onError);
+          server.once('error', onError);
+          server.listen(LEGACY_PORT, host, () => {
+            server.removeListener('error', onError);
             console.error(`Legacy HTTP server also listening on ${host}:${LEGACY_PORT} for old plugins`);
             resolve();
           });
@@ -1094,16 +1087,16 @@ class RobloxStudioMCPServer {
     await this.server.connect(transport);
     console.error('Roblox Studio MCP server running on stdio');
 
-    (httpServer as any).setMCPServerActive(true);
+    (httpApp as any).setMCPServerActive(true);
     console.error('MCP server marked as active');
 
     console.error('Waiting for Studio plugin to connect...');
 
     setInterval(() => {
-      (httpServer as any).trackMCPActivity();
-      if (legacyServer) (legacyServer as any).trackMCPActivity();
-      const pluginConnected = (httpServer as any).isPluginConnected();
-      const mcpActive = (httpServer as any).isMCPServerActive();
+      (httpApp as any).trackMCPActivity();
+      if (legacyApp) (legacyApp as any).trackMCPActivity();
+      const pluginConnected = (httpApp as any).isPluginConnected();
+      const mcpActive = (httpApp as any).isMCPServerActive();
 
       if (pluginConnected && mcpActive) {
       } else if (pluginConnected && !mcpActive) {


### PR DESCRIPTION
## Problem

When multiple MCP server instances run simultaneously (e.g., multiple AI coding sessions connecting to the same Roblox Studio), the port retry logic silently crashes instead of trying the next available port.

**Root cause:** The error handler is attached to the Express app, but `app.listen()` internally creates a new `net.Server` — the `EADDRINUSE` error is emitted on that internal server, not on the Express app. This results in an unhandled `'error'` event that crashes the process.

```
Error: listen EADDRINUSE: address already in use 0.0.0.0:58741
Emitted 'error' event on Server instance at: ...
```

## Fix

Create `http.Server` explicitly via `http.createServer(expressApp)` and attach the error handler to it, so `EADDRINUSE` is properly caught and the retry loop works as intended.

**Before (broken):**
```typescript
httpServer.once('error', onError);     // ← on Express app (wrong target)
httpServer.listen(port, host, () => {  // ← internally creates net.Server
```

**After (fixed):**
```typescript
const server = http.createServer(httpApp);
server.once('error', onError);         // ← on actual net.Server (correct target)
server.listen(port, host, () => {      // ← same server, error is caught
```

Applied to both the main port binding loop and the legacy port listener.

## Testing

Verified with a test that occupies the base port and confirms the server retries on the next port:

```
Blocker listening on 59000
Port 59000 in use, trying next...
HTTP server listening on 0.0.0.0:59001 for Studio plugin
✅ PASS: Port retry works correctly!
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when the base port is in use by listening on an explicit http.Server and catching EADDRINUSE, so the server retries the next port instead of exiting. Applied to both the main binding loop and the legacy listener.

- **Bug Fixes**
  - Create http.Server via http.createServer(app) and attach once('error') to it.
  - Port retry loop now properly continues on EADDRINUSE; same fix for legacy port 3002.
  - Keep Express app references for activity/connection checks (httpApp/legacyApp).

<sup>Written for commit bccd75480fb960a8bafb3703d05fbb0408c8965f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP server initialization and streamlined error handling for improved system stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->