### PR TITLE
Improve request lifecycle and connection state management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,158 @@
+# CLAUDE.md - Roblox Studio MCP Server
+
+## Project Overview
+
+Roblox Studio MCP Server connects AI assistants (Claude, Gemini, Codex) to Roblox Studio via the Model Context Protocol (MCP). It enables AI to explore game structure, read/edit scripts, manipulate instances, and perform bulk operations -- all locally over HTTP.
+
+**Version**: 2.3.0
+**License**: MIT
+**NPM**: `robloxstudio-mcp`
+
+## Architecture
+
+```
+AI Assistant (Claude/Gemini/Codex)
+        |  stdio (MCP protocol)
+        v
+MCP Server (Node.js)      ← src/index.ts
+  - Tool definitions       ← 40+ tools
+  - Bridge service         ← src/bridge-service.ts (UUID-based request queue)
+  - HTTP server            ← src/http-server.ts (Express, ports 58741-58745)
+        |  HTTP polling (500ms)
+        v
+Roblox Studio Plugin       ← studio-plugin/
+  - Polls GET /poll for pending requests
+  - Processes via handler modules
+  - Responds via POST /response
+```
+
+Communication is **polling-based** (not WebSocket) because the Roblox Studio plugin environment only supports HTTP requests via `HttpService.RequestAsync`.
+
+## Quick Reference
+
+### Build & Run
+
+```bash
+npm install          # Install dependencies
+npm run build        # Compile TypeScript (src/ -> dist/)
+npm run dev          # Run dev server via tsx
+npm start            # Run compiled dist/index.js
+npm test             # Run Jest test suite
+npm run typecheck    # Type-check without emitting
+npm run lint         # ESLint
+npm run build:plugin # Build Roblox Studio plugin (requires rbxtsc)
+npm run build:all    # Build both server and plugin
+```
+
+### Environment Variables
+
+- `ROBLOX_STUDIO_PORT` - Base port (default: `58741`, tries up to 58745)
+- `ROBLOX_STUDIO_HOST` - Host binding (default: `0.0.0.0`)
+
+## Project Structure
+
+```
+src/
+  index.ts                  # MCP server entry point, tool handler dispatch
+  bridge-service.ts         # Request queue: UUID tracking, dispatch, timeout, cleanup
+  http-server.ts            # Express HTTP server: /poll, /ready, /disconnect, /response, /mcp/*
+  tools/
+    index.ts                # RobloxStudioTools class - wraps all 40+ tool implementations
+    studio-client.ts        # StudioHttpClient - sends requests through bridge
+  __tests__/
+    integration.test.ts     # Full connection lifecycle + request/response flow
+    bridge-service.test.ts  # Bridge service unit tests
+    http-server.test.ts     # HTTP endpoint tests
+    smoke.test.ts           # Basic smoke tests
+
+studio-plugin/              # Roblox Studio plugin (TypeScript -> Luau via roblox-ts)
+  src/
+    server/
+      index.server.ts       # Plugin entry point (toolbar, UI, lifecycle)
+    modules/
+      Communication.ts      # Polling loop, port discovery, activate/deactivate
+      State.ts              # Connection state management (ports, retry config)
+      UI.ts                 # Plugin UI rendering and status indicators
+      Utils.ts              # Utility functions
+      handlers/
+        QueryHandlers.ts    # get_file_tree, search_files, get_place_info, etc.
+        PropertyHandlers.ts # set_property, mass_set_property, etc.
+        InstanceHandlers.ts # create_object, delete_object, smart_duplicate, etc.
+        ScriptHandlers.ts   # get_script_source, set_script_source, edit_script_lines, etc.
+        MetadataHandlers.ts # attributes, tags, selection, execute_luau
+        TestHandlers.ts     # start_playtest, stop_playtest, get_playtest_output
+    types/
+      index.d.ts            # TypeScript type definitions
+
+scripts/
+  build-plugin.mjs          # Plugin build script
+```
+
+## Key Files to Know
+
+| File | Purpose |
+|------|---------|
+| `src/index.ts` | Main entry. All 40+ MCP tool definitions and dispatch logic. |
+| `src/bridge-service.ts` | Core request queue. Tracks pending/dispatched requests with UUIDs, handles timeouts (60s), prevents duplicate dispatch. |
+| `src/http-server.ts` | Express server. Plugin polls `/poll`, sends responses to `/response`. Connection state tracking. |
+| `studio-plugin/src/modules/Communication.ts` | Plugin-side polling loop, port discovery (58741-58745), retry with exponential backoff, response sending with retry. |
+| `studio-plugin/src/modules/State.ts` | Connection configuration: poll interval (0.5s), max retry delay (5s), backoff multiplier (1.2x), failure thresholds. |
+
+## Connection Flow
+
+1. MCP server starts, listens on ports 58741-58745 (+ legacy 3002)
+2. MCP server connects stdio transport to AI assistant
+3. Plugin activates, discovers available port via `GET /status`
+4. Plugin sends `POST /ready` to signal connection
+5. Plugin polls `GET /poll` every 500ms for pending requests
+6. AI calls MCP tool -> bridge queues request -> plugin picks up via poll
+7. Plugin processes request through handler -> sends `POST /response`
+8. Bridge resolves the promise -> result returned to AI
+
+## Request Lifecycle
+
+- Requests get a UUID and are stored in `BridgeService.pendingRequests`
+- `getPendingRequest()` returns oldest undispatched request and marks it as dispatched
+- Dispatched requests won't be returned again (prevents duplicate processing)
+- If a dispatched request isn't resolved within 45s, it becomes re-dispatchable
+- Overall timeout is 60s, after which the request is rejected
+- On plugin disconnect (`/disconnect` or `/ready`), all pending requests are cleared
+
+## Retry & Reconnection
+
+**Plugin side** (Communication.ts):
+- Normal poll interval: 500ms
+- After 5+ consecutive failures: exponential backoff (1.2x multiplier, max 5s)
+- After 50 failures: shows "Server unavailable" error state
+- Response sending retries up to 3 times with incremental delay
+- Port discovery runs before polling starts to find correct server
+
+**Server side** (http-server.ts):
+- Plugin activity timeout: 30s (plugin must poll within this window)
+- MCP active state: boolean flag, set to false on transport close
+- Request timeout: 60s
+- Cleanup interval: 10s
+
+## Testing
+
+Tests use Jest with ts-jest. Run with `npm test`.
+
+- **32 tests** across 4 test suites
+- Tests cover: connection lifecycle, request/response flow, timeout handling, disconnect recovery, bridge service operations, smoke tests
+- Test timeout: 30s per test (jest.config.js)
+- Uses `supertest` for HTTP endpoint testing
+- Uses `jest.useFakeTimers()` for timeout-related tests
+
+## Important Implementation Details
+
+- All server logging goes to `stderr` (not stdout) since stdout is used for MCP stdio transport
+- The bridge marks requests as `dispatched` to prevent the same request being sent to the plugin multiple times during concurrent polls
+- The plugin processes requests asynchronously via `task.spawn()` so polling continues during request handling
+- Port discovery in the plugin prefers servers with `pluginConnected === false` and `mcpServerActive === true`, but falls back to any server with MCP active
+- Legacy port 3002 is maintained for backward compatibility with older plugin versions
+
+## Dependencies
+
+**Runtime**: `@modelcontextprotocol/sdk`, `express`, `cors`, `uuid`, `ws`, `node-fetch`
+**Dev**: `typescript`, `jest`, `ts-jest`, `supertest`, `tsx`, `eslint`
+**Plugin**: `roblox-ts`, `@rbxts/types`, `@rbxts/services`

--- a/src/__tests__/bridge-service.test.ts
+++ b/src/__tests__/bridge-service.test.ts
@@ -52,15 +52,25 @@ describe('BridgeService', () => {
       await expect(requestPromise).rejects.toEqual(error);
     });
 
-    test('should timeout request after 30 seconds', async () => {
+    test('should timeout request after 60 seconds', async () => {
       const endpoint = '/api/test';
       const data = { test: 'data' };
 
       const requestPromise = bridgeService.sendRequest(endpoint, data);
 
-      jest.advanceTimersByTime(31000);
+      jest.advanceTimersByTime(61000);
 
       await expect(requestPromise).rejects.toThrow('Request timeout');
+    });
+
+    test('should not return already dispatched request', async () => {
+      bridgeService.sendRequest('/api/test1', { order: 1 });
+
+      const first = bridgeService.getPendingRequest();
+      expect(first?.request.data.order).toBe(1);
+
+      const second = bridgeService.getPendingRequest();
+      expect(second).toBeNull();
     });
   });
 
@@ -73,7 +83,7 @@ describe('BridgeService', () => {
         bridgeService.sendRequest('/api/test3', {})
       ];
 
-      jest.advanceTimersByTime(31000);
+      jest.advanceTimersByTime(61000);
 
       bridgeService.cleanupOldRequests();
 

--- a/src/__tests__/http-server.test.ts
+++ b/src/__tests__/http-server.test.ts
@@ -41,7 +41,7 @@ describe('HTTP Server', () => {
         .post('/ready')
         .expect(200);
 
-      expect(response.body).toEqual({ success: true });
+      expect(response.body).toMatchObject({ success: true });
       expect(app.isPluginConnected()).toBe(true);
     });
 
@@ -78,7 +78,7 @@ describe('HTTP Server', () => {
       expect(app.isPluginConnected()).toBe(true);
 
       const originalDateNow = Date.now;
-      Date.now = jest.fn(() => originalDateNow() + 11000);
+      Date.now = jest.fn(() => originalDateNow() + 31000);
 
       expect(app.isPluginConnected()).toBe(false);
 
@@ -190,25 +190,14 @@ describe('HTTP Server', () => {
   });
 
   describe('MCP Server State Management', () => {
-    test('should track MCP server activity', async () => {
-      app.setMCPServerActive(true);
-      expect(app.isMCPServerActive()).toBe(true);
-
-      app.trackMCPActivity();
-
-      expect(app.isMCPServerActive()).toBe(true);
-    });
-
-    test('should timeout MCP server after inactivity', async () => {
-      app.setMCPServerActive(true);
-      expect(app.isMCPServerActive()).toBe(true);
-
-      const originalDateNow = Date.now;
-      Date.now = jest.fn(() => originalDateNow() + 16000);
-
+    test('should track MCP server active state', async () => {
       expect(app.isMCPServerActive()).toBe(false);
 
-      Date.now = originalDateNow;
+      app.setMCPServerActive(true);
+      expect(app.isMCPServerActive()).toBe(true);
+
+      app.setMCPServerActive(false);
+      expect(app.isMCPServerActive()).toBe(false);
     });
   });
 
@@ -226,7 +215,7 @@ describe('HTTP Server', () => {
         pluginConnected: true,
         mcpServerActive: true
       });
-      expect(response.body.lastMCPActivity).toBeGreaterThan(0);
+      expect(response.body.lastPluginActivity).toBeGreaterThan(0);
       expect(response.body.uptime).toBeGreaterThan(0);
     });
   });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -196,7 +196,7 @@ describe('Integration Tests', () => {
 
       await request(app).get('/poll').expect(200);
 
-      jest.advanceTimersByTime(31000);
+      jest.advanceTimersByTime(61000);
 
       await expect(timeoutPromise).rejects.toThrow('Request timeout');
 


### PR DESCRIPTION
## Summary
This PR refactors the request lifecycle management and connection state tracking to improve reliability and observability. Key improvements include better request dispatch tracking, more robust plugin reconnection handling, and clearer connection state logging.

## Key Changes

### Request Lifecycle Management (bridge-service.ts)
- Extended request timeout from 30s to 60s to accommodate slower operations
- Added `dispatched` flag and `dispatchedAt` timestamp to track request state
- Implemented stale dispatch recovery: requests marked as dispatched for >45s become re-dispatchable
- `getPendingRequest()` now marks requests as dispatched to prevent duplicate processing
- Added `getPendingCount()` and `getDispatchedCount()` methods for monitoring

### Plugin Communication Improvements (Communication.ts)
- Added retry logic to `sendResponse()`: up to 3 attempts with incremental backoff (0.5s, 1s)
- Enhanced port discovery in `discoverPort()`: prefers servers with `pluginConnected === false && mcpServerActive === true`, falls back to any server with MCP active
- Moved heartbeat connection setup into async task to prevent race conditions
- Added `isActive` check in heartbeat loop to prevent polling after deactivation

### Connection State Tracking (http-server.ts)
- Removed activity-based timeout for MCP server (now uses explicit `setMCPServerActive()` calls)
- Extended plugin activity timeout from 10s to 30s for more stable connections
- Simplified `isMCPServerActive()` to return explicit state instead of time-based check
- Added request counts (`pendingRequests`, `dispatchedRequests`) to `/status` endpoint
- Improved `/ready` endpoint: logs reconnection events and returns `mcpServerActive` status
- Added logging for `/disconnect` events

### Server Lifecycle Management (index.ts)
- Added `onclose` handler to mark MCP server as inactive when transport closes
- Improved connection state logging with state machine (connected/plugin-only/mcp-only/waiting)
- Only log state changes to reduce noise
- Added request queue monitoring: logs pending/dispatched counts when non-zero
- Extended cleanup interval from 5s to 10s

### Test Updates
- Updated timeout assertions to match new 60s timeout
- Added test for duplicate request prevention
- Simplified MCP server state tests (removed activity-based timeout tests)
- Updated plugin activity timeout test from 11s to 31s
- Fixed `/status` endpoint assertions to check for new fields

## Notable Implementation Details
- Request dispatch marking prevents the same request being sent to the plugin multiple times during concurrent polls
- Stale dispatch recovery (45s threshold) allows requests to be re-sent if the plugin fails to respond
- Plugin reconnection clears all pending requests to prevent stale request processing
- All logging goes to stderr to preserve stdout for MCP stdio transport
- Connection state is now more explicit and easier to debug via `/status` endpoint

https://claude.ai/code/session_01MMmjDhnuhjpcMzRvrnVQ3j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frequent disconnects and duplicate request processing between the MCP server and the Roblox Studio plugin by making connection state explicit and hardening request dispatch. Adds clearer status reporting, increases timeouts, and includes a new CLAUDE.md for setup and troubleshooting.

- **Bug Fixes**
  - Prevented duplicate dispatch by tracking dispatched requests and allowing re-dispatch after 45s; cleared queue on plugin reconnect.
  - Replaced time-based MCP activity checks with an explicit active flag and raised plugin activity timeout to 30s to avoid false 503s/disconnects.
  - Stabilized plugin comms: response POST retries (3 attempts), start polling after port discovery and /ready, and improved port selection (prefer MCP-active; fallback allowed).

- **Refactors**
  - Increased request timeout to 60s; added pending/dispatched counts to /status; queue monitoring logs only when non-zero.
  - /ready now returns mcpServerActive and logs connect/reconnect; /disconnect logs; state machine logs only on changes; MCP transport onclose marks server inactive; cleanup interval set to 10s.
  - Updated tests for new timeouts/fields and added CLAUDE.md with architecture, build/run steps, and connection flow.

<sup>Written for commit c211ccc3dcfcf14ef5f914b267b565bd6b889401. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic retry mechanism for plugin communication with progressive backoff
  * Enhanced server health endpoint with pending and dispatched request metrics
  * Improved connection state tracking with detailed lifecycle logging
  * Extended plugin activity detection timeout window for better stability

* **Bug Fixes**
  * Optimized request timeout behavior and cleanup of stale dispatched requests

* **Documentation**
  * Added comprehensive project architecture and implementation guide

* **Tests**
  * Updated test coverage for extended timeout scenarios and request dispatch validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->