### PR TITLE
fix: decode Windows file URL paths when resolving build-library

### DIFF
--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -707,7 +707,7 @@ export class RobloxStudioTools {
 
   private static findLibraryPath(): string {
     // Walk up from the script location to find the repo root (has .gitignore + package.json)
-    let dir = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1'));
+    let dir = path.dirname(decodeURIComponent(new URL(import.meta.url).pathname).replace(/^\/([A-Z]:)/, '$1'));
     for (let i = 0; i < 6; i++) {
       const candidate = path.join(dir, 'build-library');
       if (fs.existsSync(candidate)) return candidate;


### PR DESCRIPTION
## summary
- fixes Windows startup failures when the user profile path contains spaces by decoding `import.meta.url` pathname before path operations.
- keeps the change intentionally minimal in `findLibraryPath()` so behavior is unchanged except for correct handling of `%20` and other encoded characters.
- fixes #57.

## Context
on Windows, `new URL(import.meta.url).pathname` returns URL-encoded text (e.g. spaces as `%20`). That encoded path was being used directly for filesystem operations, which can lead to invalid paths like `C:\Users\Name%20With%20Space\...` and startup errors when creating `build-library`.

## Verification
- `npm run build -w packages/core` passes locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode Windows file URL paths when resolving build-library to prevent Windows startup failures when the user profile path contains spaces. We now decode import.meta.url.pathname before path operations so path checks use real filesystem paths; no other behavior changes.

<sup>Written for commit 240da0d5abbe7eb3ffe6652847fa0bfe4bec79d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed library path resolution to properly handle URLs containing percent-encoded characters, ensuring correct path extraction in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->