### PR TITLE
Reduce HTTP server port retry attempts from 5 to 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robloxstudio-mcp-monorepo",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robloxstudio-mcp-monorepo",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "workspaces": [
         "packages/*"
       ],
@@ -8029,7 +8029,7 @@
     },
     "packages/core": {
       "name": "@robloxstudio-mcp/core",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",
         "@types/cors": "^2.8.17",
@@ -8051,7 +8051,7 @@
       }
     },
     "packages/robloxstudio-mcp": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.6.0",

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -239,18 +239,18 @@ export class RobloxStudioMCPServer {
     // Try to bind as primary
     try {
       primaryApp = createHttpServer(this.tools, this.bridge, this.allowedToolNames);
-      const result = await listenWithRetry(primaryApp, host, basePort, 5);
+      const result = await listenWithRetry(primaryApp, host, basePort, 1);
       httpHandle = result.server;
       boundPort = result.port;
       console.error(`HTTP server listening on ${host}:${boundPort} for Studio plugin (primary mode)`);
     } catch {
-      // All ports in use — fall back to proxy mode
+      // Base port in use — fall back to proxy mode
       bridgeMode = 'proxy';
       primaryApp = undefined;
       const proxyBridge = new ProxyBridgeService(`http://localhost:${basePort}`);
       this.bridge = proxyBridge;
       this.tools = new RobloxStudioTools(this.bridge);
-      console.error(`All ports ${basePort}-${basePort + 4} in use — entering proxy mode (forwarding to localhost:${basePort})`);
+      console.error(`Port ${basePort} in use — entering proxy mode (forwarding to localhost:${basePort})`);
 
       // Periodically try to promote to primary if the port frees up
       const promotionIntervalMs = parseInt(process.env.ROBLOX_STUDIO_PROXY_PROMOTION_INTERVAL_MS || '5000');
@@ -259,7 +259,7 @@ export class RobloxStudioMCPServer {
           this.bridge = new BridgeService();
           this.tools = new RobloxStudioTools(this.bridge);
           primaryApp = createHttpServer(this.tools, this.bridge, this.allowedToolNames);
-          const result = await listenWithRetry(primaryApp, host, basePort, 5);
+          const result = await listenWithRetry(primaryApp, host, basePort, 1);
           httpHandle = result.server;
           boundPort = result.port;
           bridgeMode = 'primary';


### PR DESCRIPTION
## Summary
This PR reduces the number of port binding retry attempts for the HTTP server from 5 to 1, and updates related error messages to reflect the new behavior.

## Key Changes
- Changed `listenWithRetry()` calls from attempting 5 ports to attempting only 1 port (the base port)
  - Updated in primary server initialization (line 242)
  - Updated in proxy mode promotion logic (line 262)
- Updated error messages to accurately reflect the new retry behavior:
  - Changed "All ports in use" to "Base port in use" in fallback comment
  - Changed "All ports ${basePort}-${basePort + 4} in use" to "Port ${basePort} in use" in console error message

## Implementation Details
Previously, the server would attempt to bind to 5 consecutive ports (basePort through basePort+4) before falling back to proxy mode. With this change, it will only attempt the single base port, making the fallback to proxy mode more immediate if that port is unavailable. This simplifies the port binding logic and makes the error messages more accurate to the actual behavior.

https://claude.ai/code/session_01XFHajLriejoJaUtACvjWBK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the HTTP server only to the base port and immediately fall back to proxy mode if it’s taken. This prevents multiple primaries on different ports and fixes Studio tool routing to the wrong bridge.

- **Bug Fixes**
  - Set listenWithRetry maxAttempts=1 in primary startup and proxy promotion.
  - Updated error/log messages to reference a single port and clarify fallback.
  - Ensures a single primary port so Studio always connects to the right instance.

- **Dependencies**
  - Bumped monorepo/package versions to 2.4.0 in package-lock.json.

<sup>Written for commit b21eb669d3eec613b3ea944a1100952bf2a5ffcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced HTTP server binding retry attempts from 5 to 1 to accelerate fallback to proxy mode when the base port is unavailable.
  * Updated server startup and proxy mode messages to clearly display specific port information instead of port ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->