### PR TITLE
Fix macOS build-library path resolution

### DIFF
--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -7,15 +7,113 @@ import * as path from 'path';
 import request from 'supertest';
 
 describe('Smoke Tests - Connection Fixes', () => {
-  test('build library should resolve inside the current project on macOS-style paths', async () => {
+  test('build library override should take precedence over the project-root path', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
     const projectRoot = path.join(tempRoot, 'my-game');
     const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+    const overrideRoot = path.join(tempRoot, 'override-library');
+    const originalOverride = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    const originalLegacyOverride = process.env.BUILD_LIBRARY_PATH;
 
     fs.mkdirSync(nestedWorkingDir, { recursive: true });
     fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
 
     const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedWorkingDir);
+    process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = overrideRoot;
+    delete process.env.BUILD_LIBRARY_PATH;
+
+    try {
+      const bridge = new BridgeService();
+      const tools = new RobloxStudioTools(bridge);
+      const result = await tools.createBuild(
+        'misc/override_build',
+        'misc',
+        { a: ['Bright red', 'Plastic'] },
+        [[0, 0, 0, 1, 1, 1, 0, 0, 0, 'a']]
+      );
+
+      const payload = JSON.parse(result.content[0].text);
+      const expectedPath = path.join(overrideRoot, 'misc', 'override_build.json');
+      const projectPath = path.join(projectRoot, 'build-library', 'misc', 'override_build.json');
+
+      expect(payload.savedTo).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+      expect(fs.existsSync(projectPath)).toBe(false);
+    } finally {
+      cwdSpy.mockRestore();
+      if (originalOverride === undefined) {
+        delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+      } else {
+        process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = originalOverride;
+      }
+      if (originalLegacyOverride === undefined) {
+        delete process.env.BUILD_LIBRARY_PATH;
+      } else {
+        process.env.BUILD_LIBRARY_PATH = originalLegacyOverride;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('build library override should fail instead of silently falling back', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
+    const projectRoot = path.join(tempRoot, 'my-game');
+    const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+    const overrideFile = path.join(tempRoot, 'override-file');
+    const originalOverride = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    const originalLegacyOverride = process.env.BUILD_LIBRARY_PATH;
+
+    fs.mkdirSync(nestedWorkingDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
+    fs.writeFileSync(overrideFile, 'not a directory');
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedWorkingDir);
+    process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = overrideFile;
+    delete process.env.BUILD_LIBRARY_PATH;
+
+    try {
+      const bridge = new BridgeService();
+      const tools = new RobloxStudioTools(bridge);
+
+      await expect(
+        tools.createBuild(
+          'misc/override_failure',
+          'misc',
+          { a: ['Bright red', 'Plastic'] },
+          [[0, 0, 0, 1, 1, 1, 0, 0, 0, 'a']]
+        )
+      ).rejects.toThrow(`override build-library`);
+
+      expect(fs.existsSync(path.join(projectRoot, 'build-library'))).toBe(false);
+    } finally {
+      cwdSpy.mockRestore();
+      if (originalOverride === undefined) {
+        delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+      } else {
+        process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = originalOverride;
+      }
+      if (originalLegacyOverride === undefined) {
+        delete process.env.BUILD_LIBRARY_PATH;
+      } else {
+        process.env.BUILD_LIBRARY_PATH = originalLegacyOverride;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('build library should resolve inside the current project on macOS-style paths', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
+    const projectRoot = path.join(tempRoot, 'my-game');
+    const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+    const originalOverride = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    const originalLegacyOverride = process.env.BUILD_LIBRARY_PATH;
+
+    fs.mkdirSync(nestedWorkingDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedWorkingDir);
+    delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    delete process.env.BUILD_LIBRARY_PATH;
 
     try {
       const bridge = new BridgeService();
@@ -34,6 +132,65 @@ describe('Smoke Tests - Connection Fixes', () => {
       expect(fs.existsSync(expectedPath)).toBe(true);
     } finally {
       cwdSpy.mockRestore();
+      if (originalOverride === undefined) {
+        delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+      } else {
+        process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = originalOverride;
+      }
+      if (originalLegacyOverride === undefined) {
+        delete process.env.BUILD_LIBRARY_PATH;
+      } else {
+        process.env.BUILD_LIBRARY_PATH = originalLegacyOverride;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('build library should fall back to the home directory when project-root is unusable', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
+    const projectRoot = path.join(tempRoot, 'my-game');
+    const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+    const originalCwd = process.cwd();
+    const originalOverride = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    const originalLegacyOverride = process.env.BUILD_LIBRARY_PATH;
+    const buildId = `misc/home_fallback_${Date.now()}`;
+    const expectedPath = path.join(os.homedir(), '.robloxstudio-mcp', 'build-library', `${buildId}.json`);
+
+    fs.mkdirSync(nestedWorkingDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
+    fs.writeFileSync(path.join(projectRoot, 'build-library'), 'not a directory');
+    delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    delete process.env.BUILD_LIBRARY_PATH;
+    process.chdir(nestedWorkingDir);
+
+    try {
+      const bridge = new BridgeService();
+      const tools = new RobloxStudioTools(bridge);
+      const result = await tools.createBuild(
+        buildId,
+        'misc',
+        { a: ['Bright red', 'Plastic'] },
+        [[0, 0, 0, 1, 1, 1, 0, 0, 0, 'a']]
+      );
+
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload.savedTo).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+      expect(fs.existsSync(path.join(nestedWorkingDir, 'build-library'))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      if (originalOverride === undefined) {
+        delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+      } else {
+        process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = originalOverride;
+      }
+      if (originalLegacyOverride === undefined) {
+        delete process.env.BUILD_LIBRARY_PATH;
+      } else {
+        process.env.BUILD_LIBRARY_PATH = originalLegacyOverride;
+      }
+      fs.rmSync(expectedPath, { force: true });
       fs.rmSync(tempRoot, { recursive: true, force: true });
     }
   });

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -146,6 +146,54 @@ describe('Smoke Tests - Connection Fixes', () => {
     }
   });
 
+  test('build library should prefer an existing cwd library over creating a new project-root library', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
+    const projectRoot = path.join(tempRoot, 'my-game');
+    const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+    const cwdLibraryPath = path.join(nestedWorkingDir, 'build-library');
+    const originalOverride = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    const originalLegacyOverride = process.env.BUILD_LIBRARY_PATH;
+
+    fs.mkdirSync(cwdLibraryPath, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedWorkingDir);
+    delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+    delete process.env.BUILD_LIBRARY_PATH;
+
+    try {
+      const bridge = new BridgeService();
+      const tools = new RobloxStudioTools(bridge);
+      const result = await tools.createBuild(
+        'misc/cwd_build',
+        'misc',
+        { a: ['Bright red', 'Plastic'] },
+        [[0, 0, 0, 1, 1, 1, 0, 0, 0, 'a']]
+      );
+
+      const payload = JSON.parse(result.content[0].text);
+      const expectedPath = path.join(cwdLibraryPath, 'misc', 'cwd_build.json');
+      const projectRootPath = path.join(projectRoot, 'build-library', 'misc', 'cwd_build.json');
+
+      expect(payload.savedTo).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+      expect(fs.existsSync(projectRootPath)).toBe(false);
+    } finally {
+      cwdSpy.mockRestore();
+      if (originalOverride === undefined) {
+        delete process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY;
+      } else {
+        process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY = originalOverride;
+      }
+      if (originalLegacyOverride === undefined) {
+        delete process.env.BUILD_LIBRARY_PATH;
+      } else {
+        process.env.BUILD_LIBRARY_PATH = originalLegacyOverride;
+      }
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test('build library should fall back to the home directory when project-root is unusable', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
     const projectRoot = path.join(tempRoot, 'my-game');

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -1,9 +1,43 @@
 import { BridgeService } from '../bridge-service.js';
 import { createHttpServer } from '../http-server.js';
 import { RobloxStudioTools } from '../tools/index.js';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import request from 'supertest';
 
 describe('Smoke Tests - Connection Fixes', () => {
+  test('build library should resolve inside the current project on macOS-style paths', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'robloxstudio-mcp-'));
+    const projectRoot = path.join(tempRoot, 'my-game');
+    const nestedWorkingDir = path.join(projectRoot, 'packages', 'server');
+
+    fs.mkdirSync(nestedWorkingDir, { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, 'package.json'), '{}');
+
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(nestedWorkingDir);
+
+    try {
+      const bridge = new BridgeService();
+      const tools = new RobloxStudioTools(bridge);
+      const result = await tools.createBuild(
+        'misc/test_build',
+        'misc',
+        { a: ['Bright red', 'Plastic'] },
+        [[0, 0, 0, 1, 1, 1, 0, 0, 0, 'a']]
+      );
+
+      const payload = JSON.parse(result.content[0].text);
+      const expectedPath = path.join(projectRoot, 'build-library', 'misc', 'test_build.json');
+
+      expect(payload.savedTo).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+    } finally {
+      cwdSpy.mockRestore();
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   test('BridgeService should be instantiable', () => {
     const bridge = new BridgeService();
     expect(bridge).toBeDefined();

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -757,19 +757,41 @@ export class RobloxStudioTools {
     return resolvedCandidate;
   }
 
+  private static findExistingWritableDirectory(candidate: string | null | undefined): string | null {
+    if (!candidate || !RobloxStudioTools.isDirectory(candidate)) {
+      return null;
+    }
+
+    const resolvedCandidate = path.resolve(candidate);
+
+    try {
+      fs.accessSync(resolvedCandidate, fs.constants.W_OK);
+      return resolvedCandidate;
+    } catch {
+      return null;
+    }
+  }
+
   private static findLibraryPath(): string {
     const overridePath = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY || process.env.BUILD_LIBRARY_PATH;
     const cwd = path.resolve(process.cwd());
     const projectRoot = RobloxStudioTools.findProjectRoot(cwd);
     const homeLibraryPath = path.join(os.homedir(), '.robloxstudio-mcp', 'build-library');
+    const projectLibraryPath = projectRoot ? path.join(projectRoot, 'build-library') : null;
+    const cwdLibraryPath = path.join(cwd, 'build-library');
 
     if (overridePath) {
       return RobloxStudioTools.ensureWritableDirectory(overridePath, 'override');
     }
 
-    if (projectRoot) {
-      const projectLibraryPath = path.join(projectRoot, 'build-library');
+    for (const candidate of [projectLibraryPath, cwdLibraryPath]) {
+      const existingPath = RobloxStudioTools.findExistingWritableDirectory(candidate);
+      if (existingPath) {
+        return existingPath;
+      }
+    }
 
+    if (projectLibraryPath) {
       try {
         return RobloxStudioTools.ensureWritableDirectory(projectLibraryPath, 'project-root');
       } catch {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -4,6 +4,7 @@ import { runBuildExecutor } from './build-executor.js';
 import { OpenCloudClient } from '../opencloud-client.js';
 import { rgbaToPng } from '../png-encoder.js';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 export class RobloxStudioTools {
@@ -706,21 +707,73 @@ export class RobloxStudioTools {
   }
 
 
-  private static findLibraryPath(): string {
-    // Walk up from the script location to find the repo root (has .gitignore + package.json)
-    let dir = path.dirname(decodeURIComponent(new URL(import.meta.url).pathname).replace(/^\/([A-Z]:)/, '$1'));
-    for (let i = 0; i < 6; i++) {
-      const candidate = path.join(dir, 'build-library');
-      if (fs.existsSync(candidate)) return candidate;
-      dir = path.dirname(dir);
+  private static findProjectRoot(startDir: string): string | null {
+    let dir = path.resolve(startDir);
+
+    while (true) {
+      if (fs.existsSync(path.join(dir, '.git')) || fs.existsSync(path.join(dir, 'package.json'))) {
+        return dir;
+      }
+
+      const parent = path.dirname(dir);
+      if (parent === dir) {
+        return null;
+      }
+      dir = parent;
     }
-    // Fallback: create next to wherever we are
-    const fallback = path.join(dir, 'build-library');
-    fs.mkdirSync(fallback, { recursive: true });
-    return fallback;
   }
 
-  private static readonly LIBRARY_PATH = RobloxStudioTools.findLibraryPath();
+  private static isDirectory(candidate: string | null | undefined): candidate is string {
+    if (!candidate) {
+      return false;
+    }
+
+    try {
+      return fs.statSync(candidate).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  private static uniquePaths(candidates: Array<string | null | undefined>): string[] {
+    return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate)).map(candidate => path.resolve(candidate)))];
+  }
+
+  private static findLibraryPath(): string {
+    const overridePath = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY || process.env.BUILD_LIBRARY_PATH;
+    const cwd = path.resolve(process.cwd());
+    const projectRoot = RobloxStudioTools.findProjectRoot(cwd);
+
+    const existingCandidates = RobloxStudioTools.uniquePaths([
+      overridePath,
+      projectRoot ? path.join(projectRoot, 'build-library') : null,
+      path.join(cwd, 'build-library'),
+    ]);
+
+    for (const candidate of existingCandidates) {
+      if (RobloxStudioTools.isDirectory(candidate)) {
+        return candidate;
+      }
+    }
+
+    const creationCandidates = RobloxStudioTools.uniquePaths([
+      overridePath,
+      projectRoot ? path.join(projectRoot, 'build-library') : null,
+      path.join(cwd, 'build-library'),
+      path.join(os.homedir(), '.robloxstudio-mcp', 'build-library'),
+    ]);
+
+    for (const candidate of creationCandidates) {
+      try {
+        fs.mkdirSync(candidate, { recursive: true });
+        return candidate;
+      } catch {
+        // Try the next candidate. This matters when the package is installed in a read-only location.
+      }
+    }
+
+    throw new Error('Unable to resolve a writable build-library path');
+  }
 
   async exportBuild(instancePath: string, outputId?: string, style: string = 'misc') {
     if (!instancePath) {
@@ -736,7 +789,7 @@ export class RobloxStudioTools {
     if (response && response.success && response.buildData) {
       const buildData = response.buildData;
       const buildId = buildData.id || `${style}/exported`;
-      const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${buildId}.json`);
+      const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${buildId}.json`);
       const dirPath = path.dirname(filePath);
 
       if (!fs.existsSync(dirPath)) {
@@ -779,7 +832,7 @@ export class RobloxStudioTools {
 
     const buildData = { id, style, bounds: computedBounds, palette, parts };
 
-    const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${id}.json`);
+    const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${id}.json`);
     const dirPath = path.dirname(filePath);
 
     if (!fs.existsSync(dirPath)) {
@@ -853,7 +906,7 @@ export class RobloxStudioTools {
     };
     if (seed !== undefined) buildData.generatorSeed = seed;
 
-    const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${id}.json`);
+    const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${id}.json`);
     const dirPath = path.dirname(filePath);
 
     if (!fs.existsSync(dirPath)) {
@@ -887,14 +940,14 @@ export class RobloxStudioTools {
     // If buildData is a string, treat it as a library ID and load the file
     let resolved: Record<string, any>;
     if (typeof buildData === 'string') {
-      const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${buildData}.json`);
+      const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${buildData}.json`);
       if (!fs.existsSync(filePath)) {
         throw new Error(`Build not found in library: ${buildData}`);
       }
       resolved = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
     } else if (buildData.id && !buildData.parts) {
       // Object with just an id — try loading from library
-      const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${buildData.id}.json`);
+      const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${buildData.id}.json`);
       if (!fs.existsSync(filePath)) {
         throw new Error(`Build not found in library: ${buildData.id}`);
       }
@@ -919,7 +972,7 @@ export class RobloxStudioTools {
   }
 
   async listLibrary(style?: string) {
-    const libraryPath = RobloxStudioTools.LIBRARY_PATH;
+    const libraryPath = RobloxStudioTools.findLibraryPath();
     const styles = style ? [style] : ['medieval', 'modern', 'nature', 'scifi', 'misc'];
     const builds: Array<{ id: string; style: string; bounds: number[]; partCount: number }> = [];
 
@@ -974,7 +1027,7 @@ export class RobloxStudioTools {
       throw new Error('Build ID is required for get_build');
     }
 
-    const filePath = path.join(RobloxStudioTools.LIBRARY_PATH, `${id}.json`);
+    const filePath = path.join(RobloxStudioTools.findLibraryPath(), `${id}.json`);
     if (!fs.existsSync(filePath)) {
       throw new Error(`Build not found in library: ${id}`);
     }
@@ -1021,7 +1074,7 @@ export class RobloxStudioTools {
       throw new Error('sceneData is required for import_scene');
     }
 
-    const libraryPath = RobloxStudioTools.LIBRARY_PATH;
+    const libraryPath = RobloxStudioTools.findLibraryPath();
     const expandedBuilds: Array<{ buildData: Record<string, any>; position: number[]; rotation: number[]; name: string }> = [];
 
     // Resolve model references from library

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -735,44 +735,49 @@ export class RobloxStudioTools {
     }
   }
 
-  private static uniquePaths(candidates: Array<string | null | undefined>): string[] {
-    return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate)).map(candidate => path.resolve(candidate)))];
+  private static ensureWritableDirectory(candidate: string, label: string): string {
+    const resolvedCandidate = path.resolve(candidate);
+
+    try {
+      fs.mkdirSync(resolvedCandidate, { recursive: true });
+    } catch (error) {
+      throw new Error(`Unable to create ${label} build-library directory at ${resolvedCandidate}: ${(error as Error).message}`);
+    }
+
+    if (!RobloxStudioTools.isDirectory(resolvedCandidate)) {
+      throw new Error(`${label} build-library path is not a directory: ${resolvedCandidate}`);
+    }
+
+    try {
+      fs.accessSync(resolvedCandidate, fs.constants.W_OK);
+    } catch (error) {
+      throw new Error(`${label} build-library directory is not writable: ${resolvedCandidate}. ${(error as Error).message}`);
+    }
+
+    return resolvedCandidate;
   }
 
   private static findLibraryPath(): string {
     const overridePath = process.env.ROBLOXSTUDIO_MCP_BUILD_LIBRARY || process.env.BUILD_LIBRARY_PATH;
     const cwd = path.resolve(process.cwd());
     const projectRoot = RobloxStudioTools.findProjectRoot(cwd);
+    const homeLibraryPath = path.join(os.homedir(), '.robloxstudio-mcp', 'build-library');
 
-    const existingCandidates = RobloxStudioTools.uniquePaths([
-      overridePath,
-      projectRoot ? path.join(projectRoot, 'build-library') : null,
-      path.join(cwd, 'build-library'),
-    ]);
-
-    for (const candidate of existingCandidates) {
-      if (RobloxStudioTools.isDirectory(candidate)) {
-        return candidate;
-      }
+    if (overridePath) {
+      return RobloxStudioTools.ensureWritableDirectory(overridePath, 'override');
     }
 
-    const creationCandidates = RobloxStudioTools.uniquePaths([
-      overridePath,
-      projectRoot ? path.join(projectRoot, 'build-library') : null,
-      path.join(cwd, 'build-library'),
-      path.join(os.homedir(), '.robloxstudio-mcp', 'build-library'),
-    ]);
+    if (projectRoot) {
+      const projectLibraryPath = path.join(projectRoot, 'build-library');
 
-    for (const candidate of creationCandidates) {
       try {
-        fs.mkdirSync(candidate, { recursive: true });
-        return candidate;
+        return RobloxStudioTools.ensureWritableDirectory(projectLibraryPath, 'project-root');
       } catch {
-        // Try the next candidate. This matters when the package is installed in a read-only location.
+        // Fall through to the user-local fallback when the project directory is read-only.
       }
     }
 
-    throw new Error('Unable to resolve a writable build-library path');
+    return RobloxStudioTools.ensureWritableDirectory(homeLibraryPath, 'home');
   }
 
   async exportBuild(instancePath: string, outputId?: string, style: string = 'misc') {


### PR DESCRIPTION
This PR fixes the `build-library` path resolution so the server no longer falls back to creating `/Users/build-library` on macOS when it cannot find an existing directory near the compiled package.

I tracked down the problem to `packages/core/src/tools/index.ts`. The previous implementation derived library location from the compiled module path and walked up a fixed number of directories. If it didn't find `build-library` it would attempt to create one next to whatever directory it ended up in. In some macOS layouts, the fallback could resolve too far up the file system and create a whole user directory, which is clearly not the intended behaviour.

This PR changes that resolver to use a safer, project-oriented lookup strategy:

- First honor ROBLOXSTUDIO_MCP_BUILD_LIBRARY or BUILD_LIBRARY_PATH if either is set.
- Otherwise resolve from process.cwd() and look for the nearest project root by walking upward until a .git directory or package.json is found.
- Prefer an existing build-library in the detected project root or current working directory.
- If no library exists yet, create one in the project root.
- If that is not writable, fall back to a user-local location at ~/.robloxstudio-mcp/build-library.

I also removed the old static cached path behavior and now resolve the library path through findLibraryPath() at each use site. That keeps all `build-library` operations consistent with the active runtime context and avoids preserving a bad path computed once at class initialization.

The same resolver is used by all build-library operations in `packages/core/src/tools/index.ts`:

- exportBuild
- createBuild
- generateBuild
- importBuild
- listLibrary
- getBuild
- importScene

This means the entire feature set now reads and writes from the same corrected location on macOS, while preserving the expected behavior on Windows.

# Why this still works on both platforms

This is not a Mac-only code path. The new logic is platform-neutral:

- It uses Node `path`, `fs`, `os`, and `process.cwd()`, which are cross-platform.
- It does not hardcode POSIX-only or Windows-only path separators.
- It still supports explicit override paths through environment variables on both platforms.
- On Windows, project-root resolution continues to work because the search is based on `.git` or `package.json`, not on any OS-specific absolute path assumption.
- On macOS, the bad fallback to `/Users/build-library` is removed because the resolver no longer derives its fallback from the compiled module location.

In practice:

- Windows users still get project-local `build-library` behavior.
- macOS users now also get project-local behavior, with a sane home-directory fallback if needed.

# Test Coverage

This PR adds a regression test in `packages/core/src/__tests__/smoke.test.ts`.

The new test:

- creates a temporary project directory,
- simulates running from a nested working directory,
- writes a minimal `package.json` at the project root,
- calls `createBuild(...)`,
- verifies that the saved file lands in `<projectRoot>/build-library/...` rather than somewhere outside the project.

That test specifically covers the macOS-style nested project case that previously allowed the resolver to wander upward and create the wrong folder.

# What this PR does not change

This PR does not change:

- package versions
- the repo version number
- published package metadata
- tool schemas
- build file formats
- library JSON structure
- API behavior other than where the library directory is resolved on disk

This is intentionally a targeted path-resolution fix plus regression coverage, not a release/versioning change.

# Verification

Completed:

- `npm run build -w packages/core`
- targeted regression test for the new path behavior

Hopefully this PR can help macOS users develop on Roblox using your project. Good stuff! Will definitely be using 😄 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build-library path resolution with project-root discovery, strict override validation, a safe home fallback, and a preference for an existing cwd library to prevent `/Users/build-library` on macOS. The resolver is used across all build-library operations.

- **Bug Fixes**
  - Honor `ROBLOXSTUDIO_MCP_BUILD_LIBRARY` or `BUILD_LIBRARY_PATH`; override must be a writable directory or it errors (no silent fallback).
  - Detect project root from `process.cwd()` by walking up to `.git` or `package.json`; create/use `build-library` there, else fall back to `~/.robloxstudio-mcp/build-library`.
  - Prefer an existing `build-library` in the current working directory instead of creating a new one at the project root.
  - Added smoke tests for override precedence, invalid override failure, project-root resolution, cwd-preference, and home fallback.

- **Refactors**
  - Removed the cached `LIBRARY_PATH`; resolve via `findLibraryPath()` at each use. Unified `exportBuild`, `createBuild`, `generateBuild`, `importBuild`, `listLibrary`, `getBuild`, and `importScene` on the new resolver.

<sup>Written for commit 9ab53e3e61685780e46bd618c384e5d345ac68d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build-library path is now configurable via environment variables, with improved runtime discovery that prefers project-root locations, reuses existing folders when present, and falls back to a per-user home-directory location if needed.

* **Tests**
  * Added filesystem smoke tests validating overrides, invalid-override errors, project-root resolution, reuse of existing folders, and home-directory fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->