### PR TITLE
fix: harden the MCP↔Studio bridge against concurrency disconnects (v2.7.1)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
   },
   "extends": [
     "eslint:recommended",
-    "@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ gemini mcp add robloxstudio-inspector npx --trust -- -y robloxstudio-mcp-inspect
 
 ---
 
-<!-- VERSION_LINE -->**v2.7.0-next.6** - 43 tools, inspector edition, monorepo architecture
+<!-- VERSION_LINE -->**v2.7.1** - 43 tools, inspector edition, monorepo architecture
 
 [Report Issues](https://github.com/boshyxd/robloxstudio-mcp/issues) | [DevForum](https://devforum.roblox.com/t/v180-roblox-studio-mcp-speed-up-your-workflow-by-letting-ai-read-paths-and-properties/3707071) | MIT Licensed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robloxstudio-mcp-monorepo",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robloxstudio-mcp/core",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/__tests__/bridge-service.test.ts
+++ b/packages/core/src/__tests__/bridge-service.test.ts
@@ -190,5 +190,21 @@ describe('BridgeService', () => {
 
       expect(bridgeService.getPendingRequest()).toBeNull();
     });
+
+    test('prefers fresh undispatched work over an older TTL-expired in-flight request', () => {
+      // An old request is dispatched, then stalls (no response arrives).
+      bridgeService.sendRequest('/api/old', { order: 1 }).catch(() => {});
+      const first = bridgeService.getPendingRequest();
+      expect(first?.request.data.order).toBe(1);
+
+      // It crosses the redispatch TTL, and meanwhile newer work arrives.
+      jest.advanceTimersByTime(11000);
+      bridgeService.sendRequest('/api/new', { order: 2 }).catch(() => {});
+
+      // The fresh undispatched request must be served before the stalled
+      // re-offer — otherwise the old request keeps leapfrogging new work.
+      const next = bridgeService.getPendingRequest();
+      expect(next?.request.data.order).toBe(2);
+    });
   });
 });

--- a/packages/core/src/__tests__/bridge-service.test.ts
+++ b/packages/core/src/__tests__/bridge-service.test.ts
@@ -17,7 +17,7 @@ describe('BridgeService', () => {
       const endpoint = '/api/test';
       const data = { test: 'data' };
 
-      const requestPromise = bridgeService.sendRequest(endpoint, data);
+      bridgeService.sendRequest(endpoint, data);
 
       const pendingRequest = bridgeService.getPendingRequest();
       expect(pendingRequest).toBeTruthy();
@@ -129,6 +129,64 @@ describe('BridgeService', () => {
       expect(thirdRequest?.request.data.order).toBe(3);
 
       bridgeService.resolveRequest(thirdRequest!.requestId, {});
+
+      expect(bridgeService.getPendingRequest()).toBeNull();
+    });
+  });
+
+  describe('In-flight dispatch tracking', () => {
+    test('does not hand out the same request twice before it resolves', () => {
+      bridgeService.sendRequest('/api/test', { order: 1 }).catch(() => {});
+
+      const first = bridgeService.getPendingRequest();
+      expect(first).toBeTruthy();
+
+      // A second poll arriving before the first request has resolved must not
+      // be handed the same request again (that causes double execution).
+      const second = bridgeService.getPendingRequest();
+      expect(second).toBeNull();
+    });
+
+    test('hands a second poll the next request instead of repeating the oldest', () => {
+      bridgeService.sendRequest('/api/test1', { order: 1 }).catch(() => {});
+      jest.advanceTimersByTime(10);
+      bridgeService.sendRequest('/api/test2', { order: 2 }).catch(() => {});
+
+      const first = bridgeService.getPendingRequest();
+      expect(first?.request.data.order).toBe(1);
+
+      // Without resolving the first, a concurrent poll should pick up the
+      // second pending request rather than starving behind the oldest.
+      const second = bridgeService.getPendingRequest();
+      expect(second?.request.data.order).toBe(2);
+    });
+
+    test('re-dispatches a request that got no response after the redispatch TTL', () => {
+      bridgeService.sendRequest('/api/test', { order: 1 }).catch(() => {});
+
+      const first = bridgeService.getPendingRequest();
+      expect(first).toBeTruthy();
+      expect(bridgeService.getPendingRequest()).toBeNull();
+
+      // Plugin never answered (dropped response / restart). After the TTL the
+      // request becomes eligible for re-dispatch so it is not lost until the
+      // full 30s request timeout.
+      jest.advanceTimersByTime(11000);
+
+      const redispatched = bridgeService.getPendingRequest();
+      expect(redispatched?.requestId).toBe(first!.requestId);
+    });
+
+    test('keeps a dispatched request reservable by its original requestId for /response', () => {
+      bridgeService.sendRequest('/api/test', { order: 1 }).catch(() => {});
+
+      const dispatched = bridgeService.getPendingRequest();
+      expect(dispatched).toBeTruthy();
+
+      // The request must remain resolvable even though it is no longer offered
+      // to new polls.
+      const response = { ok: true };
+      bridgeService.resolveRequest(dispatched!.requestId, response);
 
       expect(bridgeService.getPendingRequest()).toBeNull();
     });

--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -215,7 +215,9 @@ describe('HTTP Server', () => {
         mcpServerActive: true
       });
       expect(response.body.lastMCPActivity).toBeGreaterThan(0);
-      expect(response.body.uptime).toBeGreaterThan(0);
+      // uptime is Date.now() - startTime, which is legitimately 0 when measured
+      // in the same millisecond as activation. Non-negative is the real invariant.
+      expect(response.body.uptime).toBeGreaterThanOrEqual(0);
     });
   });
 });

--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -240,4 +240,11 @@ describe('isPortInUseError', () => {
   test('false for undefined', () => {
     expect(isPortInUseError(undefined)).toBe(false);
   });
+
+  test('false for an unrelated error whose message merely contains "in use"', () => {
+    // The message fallback must be anchored to listenWithRetry's aggregate
+    // phrasing, not any "in use" substring — otherwise it re-introduces the very
+    // masking the helper exists to prevent.
+    expect(isPortInUseError(new Error('GPU resource currently in use'))).toBe(false);
+  });
 });

--- a/packages/core/src/__tests__/http-server.test.ts
+++ b/packages/core/src/__tests__/http-server.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import { createHttpServer } from '../http-server.js';
+import { createHttpServer, isPortInUseError } from '../http-server.js';
 import { RobloxStudioTools } from '../tools/index.js';
 import { BridgeService } from '../bridge-service.js';
 import { Application } from 'express';
@@ -219,5 +219,25 @@ describe('HTTP Server', () => {
       // in the same millisecond as activation. Non-negative is the real invariant.
       expect(response.body.uptime).toBeGreaterThanOrEqual(0);
     });
+  });
+});
+
+describe('isPortInUseError', () => {
+  test('true when the error carries the EADDRINUSE code', () => {
+    const err = Object.assign(new Error('listen EADDRINUSE: address already in use'), { code: 'EADDRINUSE' });
+    expect(isPortInUseError(err)).toBe(true);
+  });
+
+  test('true for the aggregate "all ports in use" error from listenWithRetry', () => {
+    expect(isPortInUseError(new Error('All ports 58741-58741 are in use. Stop some MCP server instances and retry.'))).toBe(true);
+  });
+
+  test('false for a non-port bind error (e.g. EACCES) so proxy mode does not mask it', () => {
+    const err = Object.assign(new Error('listen EACCES: permission denied'), { code: 'EACCES' });
+    expect(isPortInUseError(err)).toBe(false);
+  });
+
+  test('false for undefined', () => {
+    expect(isPortInUseError(undefined)).toBe(false);
   });
 });

--- a/packages/core/src/bridge-service.ts
+++ b/packages/core/src/bridge-service.ts
@@ -118,20 +118,27 @@ export class BridgeService {
   getPendingRequest(callerRole = 'edit'): { requestId: string; request: { endpoint: string; data: any } } | null {
 
     const now = Date.now();
-    let oldestRequest: PendingRequest | null = null;
+    let oldestUndispatched: PendingRequest | null = null;
+    let oldestExpired: PendingRequest | null = null;
 
     for (const request of this.pendingRequests.values()) {
       if (request.target !== callerRole) continue;
-      // Skip requests already handed to a poller, unless they have gone
-      // unanswered past the redispatch TTL.
-      if (request.dispatchedAt !== undefined && now - request.dispatchedAt < this.redispatchTimeout) {
-        continue;
-      }
-      if (!oldestRequest || request.timestamp < oldestRequest.timestamp) {
-        oldestRequest = request;
+
+      if (request.dispatchedAt === undefined) {
+        // Fresh, never-dispatched work — always preferred.
+        if (!oldestUndispatched || request.timestamp < oldestUndispatched.timestamp) {
+          oldestUndispatched = request;
+        }
+      } else if (now - request.dispatchedAt >= this.redispatchTimeout) {
+        // In-flight but unanswered past the TTL — eligible only as a fallback so
+        // a stalled re-offer cannot leapfrog newer undispatched work.
+        if (!oldestExpired || request.timestamp < oldestExpired.timestamp) {
+          oldestExpired = request;
+        }
       }
     }
 
+    const oldestRequest = oldestUndispatched ?? oldestExpired;
     if (oldestRequest) {
       oldestRequest.dispatchedAt = now;
       return {

--- a/packages/core/src/bridge-service.ts
+++ b/packages/core/src/bridge-service.ts
@@ -13,6 +13,7 @@ interface PendingRequest {
   data: any;
   target: string;
   timestamp: number;
+  dispatchedAt?: number;
   resolve: (value: any) => void;
   reject: (error: any) => void;
   timeoutId: ReturnType<typeof setTimeout>;
@@ -25,6 +26,12 @@ export class BridgeService {
   private instances: Map<string, PluginInstance> = new Map();
   private nextClientIndex = 1;
   private requestTimeout = 30000;
+  // Once a request has been handed to a poller it is "in flight" and is not
+  // offered to other polls until this TTL elapses. The TTL lets a request that
+  // never got a response (dropped /response, plugin restart) be re-dispatched
+  // before it hits the full request timeout, while preventing the same request
+  // from being executed many times by successive fast polls.
+  private redispatchTimeout = 10000;
 
   registerInstance(instanceId: string, role: string): string {
     let assignedRole = role;
@@ -110,16 +117,23 @@ export class BridgeService {
 
   getPendingRequest(callerRole = 'edit'): { requestId: string; request: { endpoint: string; data: any } } | null {
 
+    const now = Date.now();
     let oldestRequest: PendingRequest | null = null;
 
     for (const request of this.pendingRequests.values()) {
       if (request.target !== callerRole) continue;
+      // Skip requests already handed to a poller, unless they have gone
+      // unanswered past the redispatch TTL.
+      if (request.dispatchedAt !== undefined && now - request.dispatchedAt < this.redispatchTimeout) {
+        continue;
+      }
       if (!oldestRequest || request.timestamp < oldestRequest.timestamp) {
         oldestRequest = request;
       }
     }
 
     if (oldestRequest) {
+      oldestRequest.dispatchedAt = now;
       return {
         requestId: oldestRequest.id,
         request: {

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -405,7 +405,10 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
 export function isPortInUseError(err: unknown): boolean {
   if (!err) return false;
   const e = err as { code?: string; message?: string };
-  return e.code === 'EADDRINUSE' || /in use/i.test(e.message ?? '');
+  // Prefer the explicit code (raw EADDRINUSE and listenWithRetry's aggregate
+  // both carry it). The message check is a narrow fallback anchored to the
+  // aggregate phrasing only — a broad /in use/ would re-mask unrelated errors.
+  return e.code === 'EADDRINUSE' || /all ports .* are in use/i.test(e.message ?? '');
 }
 
 /**

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -397,6 +397,18 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
 }
 
 /**
+ * Classify a primary-bind failure. Returns true only when the base port is
+ * genuinely occupied, so falling back to proxy mode is the correct response.
+ * Other bind errors (EACCES, bad host, ...) must NOT be masked by proxy mode —
+ * they should surface instead of silently forwarding to a primary that isn't there.
+ */
+export function isPortInUseError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as { code?: string; message?: string };
+  return e.code === 'EADDRINUSE' || /in use/i.test(e.message ?? '');
+}
+
+/**
  * Attempt to bind an Express app to a port, using an explicit http.Server
  * so that EADDRINUSE errors are properly caught.
  */
@@ -422,7 +434,9 @@ export function listenWithRetry(
         return;
       }
     }
-    reject(new Error(`All ports ${startPort}-${startPort + maxAttempts - 1} are in use. Stop some MCP server instances and retry.`));
+    const exhausted = new Error(`All ports ${startPort}-${startPort + maxAttempts - 1} are in use. Stop some MCP server instances and retry.`) as NodeJS.ErrnoException;
+    exhausted.code = 'EADDRINUSE';
+    reject(exhausted);
   });
 }
 

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -94,20 +94,25 @@ export class RobloxStudioMCPServer {
     // Try to bind as primary
     try {
       primaryApp = createHttpServer(this.tools, this.bridge, this.allowedToolNames, this.config);
-      const result = await listenWithRetry(primaryApp, host, basePort, 5);
+      // Only the base port is a valid primary: the Studio plugin polls that one
+      // port. If it is already taken (another agent owns the bridge) we must not
+      // bind a second primary on 58742+ that no plugin will ever poll — fall
+      // through to proxy mode instead so every agent shares the one bridge.
+      const result = await listenWithRetry(primaryApp, host, basePort, 1);
       httpHandle = result.server;
       boundPort = result.port;
       console.error(`HTTP server listening on ${host}:${boundPort} for Studio plugin (primary mode)`);
       console.error(`Streamable HTTP MCP endpoint: http://localhost:${boundPort}/mcp`);
     } catch (err) {
-      // All ports in use — fall back to proxy mode
+      // Base port already owned by another agent — share its bridge via proxy
+      // mode instead of binding a second primary the plugin would never poll.
       console.error(`Could not bind primary HTTP server: ${(err as Error).message}`);
       bridgeMode = 'proxy';
       primaryApp = undefined;
       const proxyBridge = new ProxyBridgeService(`http://localhost:${basePort}`);
       this.bridge = proxyBridge;
       this.tools = new RobloxStudioTools(this.bridge);
-      console.error(`All ports ${basePort}-${basePort + 4} in use — entering proxy mode (forwarding to localhost:${basePort})`);
+      console.error(`Port ${basePort} already in use — entering proxy mode (forwarding to the primary on localhost:${basePort})`);
 
       // Periodically try to promote to primary if the port frees up
       const promotionIntervalMs = parseInt(process.env.ROBLOX_STUDIO_PROXY_PROMOTION_INTERVAL_MS || '5000');
@@ -116,7 +121,7 @@ export class RobloxStudioMCPServer {
           this.bridge = new BridgeService();
           this.tools = new RobloxStudioTools(this.bridge);
           primaryApp = createHttpServer(this.tools, this.bridge, this.allowedToolNames, this.config);
-          const result = await listenWithRetry(primaryApp, host, basePort, 5);
+          const result = await listenWithRetry(primaryApp, host, basePort, 1);
           httpHandle = result.server;
           boundPort = result.port;
           bridgeMode = 'primary';

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -7,7 +7,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import http from 'http';
-import { createHttpServer, listenWithRetry, TOOL_HANDLERS } from './http-server.js';
+import { createHttpServer, listenWithRetry, isPortInUseError, TOOL_HANDLERS } from './http-server.js';
 import { RobloxStudioTools } from './tools/index.js';
 import { BridgeService } from './bridge-service.js';
 import { ProxyBridgeService } from './proxy-bridge-service.js';
@@ -104,6 +104,13 @@ export class RobloxStudioMCPServer {
       console.error(`HTTP server listening on ${host}:${boundPort} for Studio plugin (primary mode)`);
       console.error(`Streamable HTTP MCP endpoint: http://localhost:${boundPort}/mcp`);
     } catch (err) {
+      if (!isPortInUseError(err)) {
+        // A real bind failure (permissions, bad host, ...) — surface it instead
+        // of silently entering proxy mode and forwarding to a primary the base
+        // port never actually accepted.
+        console.error(`Fatal: could not bind primary HTTP server: ${(err as Error).message}`);
+        throw err;
+      }
       // Base port already owned by another agent — share its bridge via proxy
       // mode instead of binding a second primary the plugin would never poll.
       console.error(`Could not bind primary HTTP server: ${(err as Error).message}`);

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -740,7 +740,7 @@ export class RobloxStudioTools {
 
   private static findProjectRoot(startDir: string): string | null {
     let dir = path.resolve(startDir);
-    while (true) {
+    for (;;) {
       if (fs.existsSync(path.join(dir, '.git')) || fs.existsSync(path.join(dir, 'package.json'))) {
         return dir;
       }

--- a/packages/robloxstudio-mcp-inspector/package.json
+++ b/packages/robloxstudio-mcp-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robloxstudio-mcp-inspector",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Read-only MCP Server for Roblox Studio - Inspect Studio data, scripts, and objects through AI tools (no write operations)",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/robloxstudio-mcp/package.json
+++ b/packages/robloxstudio-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robloxstudio-mcp",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "MCP Server for Roblox Studio Integration - Access Studio data, scripts, and objects through AI tools",
   "main": "dist/index.js",
   "type": "module",

--- a/studio-plugin/MCPInspectorPlugin.rbxmx
+++ b/studio-plugin/MCPInspectorPlugin.rbxmx
@@ -138,19 +138,56 @@ local function processRequest(request)
 	end
 end
 local function sendResponse(conn, requestId, responseData)
-	pcall(function()
-		HttpService:RequestAsync({
-			Url = `{conn.serverUrl}/response`,
-			Method = "POST",
-			Headers = {
-				["Content-Type"] = "application/json",
-			},
-			Body = HttpService:JSONEncode({
-				requestId = requestId,
-				response = responseData,
-			}),
-		})
-	end)
+	local body = HttpService:JSONEncode({
+		requestId = requestId,
+		response = responseData,
+	})
+	local maxAttempts = 3
+	for attempt = 1, maxAttempts do
+		local ok, result = pcall(function()
+			return HttpService:RequestAsync({
+				Url = `{conn.serverUrl}/response`,
+				Method = "POST",
+				Headers = {
+					["Content-Type"] = "application/json",
+				},
+				Body = body,
+			})
+		end)
+		if ok and result.Success then
+			return nil
+		end
+		if attempt < maxAttempts then
+			task.wait(0.2 * attempt)
+		else
+			-- Don't let a dropped response vanish silently into a 30s server-side
+			-- timeout — make it visible in the Output window.
+			local reason = if ok then `HTTP {result.StatusCode}` else tostring(result)
+			warn(`[robloxstudio-mcp] failed to deliver response for request {requestId} after {maxAttempts} attempts: {reason}`)
+		end
+	end
+end
+-- Dedupe by requestId so a request the server re-dispatches (because a /response
+-- was lost or it crossed the redispatch TTL while still running) is never
+-- executed twice. While "processing" we ignore repeats; once "done" we re-send
+-- the cached response instead of re-running the handler.
+local handledRequests = {}
+local handledOrder = {}
+local MAX_HANDLED_REQUESTS = 128
+local function rememberHandledRequest(requestId, entry)
+	local _requestId = requestId
+	if not (handledRequests[_requestId] ~= nil) then
+		local _requestId_1 = requestId
+		table.insert(handledOrder, _requestId_1)
+		if #handledOrder > MAX_HANDLED_REQUESTS then
+			local oldest = handledOrder[1]
+			table.remove(handledOrder, 1)
+			handledRequests[oldest] = nil
+		end
+	end
+	local _requestId_1 = requestId
+	local _entry = entry
+	handledRequests[_requestId_1] = _entry
 end
 local function getConnectionStatus(connIndex)
 	local conn = State.getConnection(connIndex)
@@ -243,19 +280,45 @@ local function pollForRequests(connIndex)
 				UI.startPulseAnimation()
 			end
 		end
-		if data.request and mcpConnected then
-			task.spawn(function()
-				local ok, response = pcall(function()
-					return processRequest(data.request)
-				end)
-				if ok then
-					sendResponse(conn, data.requestId, response)
-				else
-					sendResponse(conn, data.requestId, {
-						error = tostring(response),
-					})
+		if data.request and mcpConnected and data.requestId ~= nil then
+			local requestId = data.requestId
+			local existing = handledRequests[requestId]
+			if existing then
+				-- Already seen this request id. If it finished, re-send the cached
+				-- result (the server only re-offers a request when it never got the
+				-- response). If it is still processing, the in-flight handler will
+				-- post the response — do nothing. Spawn so retry waits never block
+				-- the poll loop.
+				if existing.status == "done" then
+					task.spawn(function()
+						return sendResponse(conn, requestId, existing.response)
+					end)
 				end
-			end)
+			else
+				rememberHandledRequest(requestId, {
+					status = "processing",
+				})
+				task.spawn(function()
+					local ok, response = pcall(function()
+						return processRequest(data.request)
+					end)
+					local finalResponse = if ok then response else {
+						error = tostring(response),
+					}
+					rememberHandledRequest(requestId, {
+						status = "done",
+						response = finalResponse,
+					})
+					sendResponse(conn, requestId, finalResponse)
+				end)
+			end
+		end
+		-- Adaptive poll cadence: poll quickly while work is flowing, back off when
+		-- idle so steady-state HTTP volume stays well under Roblox's rate limit.
+		if data.request then
+			conn.currentPollInterval = conn.pollInterval
+		else
+			conn.currentPollInterval = math.min(conn.currentPollInterval * 1.5, conn.maxIdlePollInterval)
 		end
 	elseif conn.isActive then
 		conn.consecutiveFailures += 1
@@ -334,6 +397,7 @@ local function activatePlugin(connIndex)
 	conn.isActive = true
 	conn.consecutiveFailures = 0
 	conn.currentRetryDelay = 0.5
+	conn.currentPollInterval = conn.pollInterval
 	ui.screenGui.Enabled = true
 	if idx == State.getActiveTabIndex() then
 		conn.serverUrl = ui.urlInput.Text
@@ -353,7 +417,7 @@ local function activatePlugin(connIndex)
 		if not conn.heartbeatConnection then
 			conn.heartbeatConnection = RunService.Heartbeat:Connect(function()
 				local now = tick()
-				local currentInterval = if conn.consecutiveFailures > 5 then conn.currentRetryDelay else conn.pollInterval
+				local currentInterval = if conn.consecutiveFailures > 5 then conn.currentRetryDelay else conn.currentPollInterval
 				if now - conn.lastPoll > currentInterval then
 					conn.lastPoll = now
 					pollForRequests(idx)
@@ -3002,6 +3066,7 @@ local _binding = Utils
 local getInstancePath = _binding.getInstancePath
 local getInstanceByPath = _binding.getInstanceByPath
 local readScriptSource = _binding.readScriptSource
+local forEachDescendant = _binding.forEachDescendant
 local function getFileTree(requestData)
 	local _condition = (requestData.path)
 	if _condition == nil then
@@ -3060,7 +3125,7 @@ local function searchFiles(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3087,11 +3152,7 @@ local function searchFiles(requestData)
 			end
 			table.insert(results, entry)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3167,7 +3228,7 @@ local function searchObjects(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3198,11 +3259,7 @@ local function searchObjects(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3373,7 +3430,7 @@ local function searchByProperty(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local success, value = pcall(function()
 			return tostring(instance[propertyName])
 		end)
@@ -3392,11 +3449,7 @@ local function searchByProperty(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		propertyName = propertyName,
 		propertyValue = propertyValue,
@@ -5064,7 +5117,7 @@ return {
         <Properties>
           <string name="Name">State</string>
           <string name="Source"><![CDATA[-- Compiled with roblox-ts v3.0.0
-local CURRENT_VERSION = "2.7.0"
+local CURRENT_VERSION = "2.7.1"
 local MAX_CONNECTIONS = 5
 local BASE_PORT = 58741
 local activeTabIndex = 0
@@ -5074,6 +5127,8 @@ local function createConnection(port)
 		serverUrl = `http://localhost:{port}`,
 		isActive = false,
 		pollInterval = 0.5,
+		maxIdlePollInterval = 2.0,
+		currentPollInterval = 0.5,
 		lastPoll = 0,
 		consecutiveFailures = 0,
 		maxFailuresBeforeError = 50,
@@ -6344,6 +6399,12 @@ local function evaluateFormula(formula, variables, instance, index)
 		return index, "Complex formulas not supported - using index value"
 	end
 end
+local function forEachDescendant(root, visit)
+	visit(root)
+	for _, child in root:GetChildren() do
+		forEachDescendant(child, visit)
+	end
+end
 local function compareVersions(v1, v2)
 	local function parseVersion(v)
 		local parts = {}
@@ -6401,6 +6462,7 @@ return {
 	convertPropertyValue = convertPropertyValue,
 	evaluateFormula = evaluateFormula,
 	compareVersions = compareVersions,
+	forEachDescendant = forEachDescendant,
 }
 ]]></string>
         </Properties>

--- a/studio-plugin/MCPInspectorPlugin.rbxmx
+++ b/studio-plugin/MCPInspectorPlugin.rbxmx
@@ -176,18 +176,33 @@ local handledOrder = {}
 local MAX_HANDLED_REQUESTS = 128
 local function rememberHandledRequest(requestId, entry)
 	local _requestId = requestId
-	if not (handledRequests[_requestId] ~= nil) then
-		local _requestId_1 = requestId
-		table.insert(handledOrder, _requestId_1)
-		if #handledOrder > MAX_HANDLED_REQUESTS then
-			local oldest = handledOrder[1]
-			table.remove(handledOrder, 1)
-			handledRequests[oldest] = nil
-		end
-	end
+	local isNew = not (handledRequests[_requestId] ~= nil)
 	local _requestId_1 = requestId
 	local _entry = entry
 	handledRequests[_requestId_1] = _entry
+	if not isNew then
+		return nil
+	end
+	local _requestId_2 = requestId
+	table.insert(handledOrder, _requestId_2)
+	if #handledOrder <= MAX_HANDLED_REQUESTS then
+		return nil
+	end
+	-- Over capacity: evict the oldest *completed* entry only. Never drop an
+	-- in-flight ("processing") id — the server may still re-dispatch it, and
+	-- losing the record here would let the handler run a second time. If the
+	-- whole window is still processing (pathological), allow a brief overflow
+	-- rather than risk a duplicate execution.
+	for i = 0, #handledOrder - 1 do
+		local id = handledOrder[i + 1]
+		local existing = handledRequests[id]
+		if not existing or existing.status == "done" then
+			local _i = i
+			table.remove(handledOrder, _i + 1)
+			handledRequests[id] = nil
+			break
+		end
+	end
 end
 local function getConnectionStatus(connIndex)
 	local conn = State.getConnection(connIndex)

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -138,19 +138,56 @@ local function processRequest(request)
 	end
 end
 local function sendResponse(conn, requestId, responseData)
-	pcall(function()
-		HttpService:RequestAsync({
-			Url = `{conn.serverUrl}/response`,
-			Method = "POST",
-			Headers = {
-				["Content-Type"] = "application/json",
-			},
-			Body = HttpService:JSONEncode({
-				requestId = requestId,
-				response = responseData,
-			}),
-		})
-	end)
+	local body = HttpService:JSONEncode({
+		requestId = requestId,
+		response = responseData,
+	})
+	local maxAttempts = 3
+	for attempt = 1, maxAttempts do
+		local ok, result = pcall(function()
+			return HttpService:RequestAsync({
+				Url = `{conn.serverUrl}/response`,
+				Method = "POST",
+				Headers = {
+					["Content-Type"] = "application/json",
+				},
+				Body = body,
+			})
+		end)
+		if ok and result.Success then
+			return nil
+		end
+		if attempt < maxAttempts then
+			task.wait(0.2 * attempt)
+		else
+			-- Don't let a dropped response vanish silently into a 30s server-side
+			-- timeout — make it visible in the Output window.
+			local reason = if ok then `HTTP {result.StatusCode}` else tostring(result)
+			warn(`[robloxstudio-mcp] failed to deliver response for request {requestId} after {maxAttempts} attempts: {reason}`)
+		end
+	end
+end
+-- Dedupe by requestId so a request the server re-dispatches (because a /response
+-- was lost or it crossed the redispatch TTL while still running) is never
+-- executed twice. While "processing" we ignore repeats; once "done" we re-send
+-- the cached response instead of re-running the handler.
+local handledRequests = {}
+local handledOrder = {}
+local MAX_HANDLED_REQUESTS = 128
+local function rememberHandledRequest(requestId, entry)
+	local _requestId = requestId
+	if not (handledRequests[_requestId] ~= nil) then
+		local _requestId_1 = requestId
+		table.insert(handledOrder, _requestId_1)
+		if #handledOrder > MAX_HANDLED_REQUESTS then
+			local oldest = handledOrder[1]
+			table.remove(handledOrder, 1)
+			handledRequests[oldest] = nil
+		end
+	end
+	local _requestId_1 = requestId
+	local _entry = entry
+	handledRequests[_requestId_1] = _entry
 end
 local function getConnectionStatus(connIndex)
 	local conn = State.getConnection(connIndex)
@@ -243,19 +280,45 @@ local function pollForRequests(connIndex)
 				UI.startPulseAnimation()
 			end
 		end
-		if data.request and mcpConnected then
-			task.spawn(function()
-				local ok, response = pcall(function()
-					return processRequest(data.request)
-				end)
-				if ok then
-					sendResponse(conn, data.requestId, response)
-				else
-					sendResponse(conn, data.requestId, {
-						error = tostring(response),
-					})
+		if data.request and mcpConnected and data.requestId ~= nil then
+			local requestId = data.requestId
+			local existing = handledRequests[requestId]
+			if existing then
+				-- Already seen this request id. If it finished, re-send the cached
+				-- result (the server only re-offers a request when it never got the
+				-- response). If it is still processing, the in-flight handler will
+				-- post the response — do nothing. Spawn so retry waits never block
+				-- the poll loop.
+				if existing.status == "done" then
+					task.spawn(function()
+						return sendResponse(conn, requestId, existing.response)
+					end)
 				end
-			end)
+			else
+				rememberHandledRequest(requestId, {
+					status = "processing",
+				})
+				task.spawn(function()
+					local ok, response = pcall(function()
+						return processRequest(data.request)
+					end)
+					local finalResponse = if ok then response else {
+						error = tostring(response),
+					}
+					rememberHandledRequest(requestId, {
+						status = "done",
+						response = finalResponse,
+					})
+					sendResponse(conn, requestId, finalResponse)
+				end)
+			end
+		end
+		-- Adaptive poll cadence: poll quickly while work is flowing, back off when
+		-- idle so steady-state HTTP volume stays well under Roblox's rate limit.
+		if data.request then
+			conn.currentPollInterval = conn.pollInterval
+		else
+			conn.currentPollInterval = math.min(conn.currentPollInterval * 1.5, conn.maxIdlePollInterval)
 		end
 	elseif conn.isActive then
 		conn.consecutiveFailures += 1
@@ -334,6 +397,7 @@ local function activatePlugin(connIndex)
 	conn.isActive = true
 	conn.consecutiveFailures = 0
 	conn.currentRetryDelay = 0.5
+	conn.currentPollInterval = conn.pollInterval
 	ui.screenGui.Enabled = true
 	if idx == State.getActiveTabIndex() then
 		conn.serverUrl = ui.urlInput.Text
@@ -353,7 +417,7 @@ local function activatePlugin(connIndex)
 		if not conn.heartbeatConnection then
 			conn.heartbeatConnection = RunService.Heartbeat:Connect(function()
 				local now = tick()
-				local currentInterval = if conn.consecutiveFailures > 5 then conn.currentRetryDelay else conn.pollInterval
+				local currentInterval = if conn.consecutiveFailures > 5 then conn.currentRetryDelay else conn.currentPollInterval
 				if now - conn.lastPoll > currentInterval then
 					conn.lastPoll = now
 					pollForRequests(idx)
@@ -3002,6 +3066,7 @@ local _binding = Utils
 local getInstancePath = _binding.getInstancePath
 local getInstanceByPath = _binding.getInstanceByPath
 local readScriptSource = _binding.readScriptSource
+local forEachDescendant = _binding.forEachDescendant
 local function getFileTree(requestData)
 	local _condition = (requestData.path)
 	if _condition == nil then
@@ -3060,7 +3125,7 @@ local function searchFiles(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3087,11 +3152,7 @@ local function searchFiles(requestData)
 			end
 			table.insert(results, entry)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3167,7 +3228,7 @@ local function searchObjects(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3198,11 +3259,7 @@ local function searchObjects(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3373,7 +3430,7 @@ local function searchByProperty(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local success, value = pcall(function()
 			return tostring(instance[propertyName])
 		end)
@@ -3392,11 +3449,7 @@ local function searchByProperty(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		propertyName = propertyName,
 		propertyValue = propertyValue,
@@ -5064,7 +5117,7 @@ return {
         <Properties>
           <string name="Name">State</string>
           <string name="Source"><![CDATA[-- Compiled with roblox-ts v3.0.0
-local CURRENT_VERSION = "2.7.0"
+local CURRENT_VERSION = "2.7.1"
 local MAX_CONNECTIONS = 5
 local BASE_PORT = 58741
 local activeTabIndex = 0
@@ -5074,6 +5127,8 @@ local function createConnection(port)
 		serverUrl = `http://localhost:{port}`,
 		isActive = false,
 		pollInterval = 0.5,
+		maxIdlePollInterval = 2.0,
+		currentPollInterval = 0.5,
 		lastPoll = 0,
 		consecutiveFailures = 0,
 		maxFailuresBeforeError = 50,
@@ -6344,6 +6399,12 @@ local function evaluateFormula(formula, variables, instance, index)
 		return index, "Complex formulas not supported - using index value"
 	end
 end
+local function forEachDescendant(root, visit)
+	visit(root)
+	for _, child in root:GetChildren() do
+		forEachDescendant(child, visit)
+	end
+end
 local function compareVersions(v1, v2)
 	local function parseVersion(v)
 		local parts = {}
@@ -6401,6 +6462,7 @@ return {
 	convertPropertyValue = convertPropertyValue,
 	evaluateFormula = evaluateFormula,
 	compareVersions = compareVersions,
+	forEachDescendant = forEachDescendant,
 }
 ]]></string>
         </Properties>

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -176,18 +176,33 @@ local handledOrder = {}
 local MAX_HANDLED_REQUESTS = 128
 local function rememberHandledRequest(requestId, entry)
 	local _requestId = requestId
-	if not (handledRequests[_requestId] ~= nil) then
-		local _requestId_1 = requestId
-		table.insert(handledOrder, _requestId_1)
-		if #handledOrder > MAX_HANDLED_REQUESTS then
-			local oldest = handledOrder[1]
-			table.remove(handledOrder, 1)
-			handledRequests[oldest] = nil
-		end
-	end
+	local isNew = not (handledRequests[_requestId] ~= nil)
 	local _requestId_1 = requestId
 	local _entry = entry
 	handledRequests[_requestId_1] = _entry
+	if not isNew then
+		return nil
+	end
+	local _requestId_2 = requestId
+	table.insert(handledOrder, _requestId_2)
+	if #handledOrder <= MAX_HANDLED_REQUESTS then
+		return nil
+	end
+	-- Over capacity: evict the oldest *completed* entry only. Never drop an
+	-- in-flight ("processing") id — the server may still re-dispatch it, and
+	-- losing the record here would let the handler run a second time. If the
+	-- whole window is still processing (pathological), allow a brief overflow
+	-- rather than risk a duplicate execution.
+	for i = 0, #handledOrder - 1 do
+		local id = handledOrder[i + 1]
+		local existing = handledRequests[id]
+		if not existing or existing.status == "done" then
+			local _i = i
+			table.remove(handledOrder, _i + 1)
+			handledRequests[id] = nil
+			break
+		end
+	end
 end
 local function getConnectionStatus(connIndex)
 	local conn = State.getConnection(connIndex)

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -107,14 +107,55 @@ function processRequest(request: RequestPayload): unknown {
 }
 
 function sendResponse(conn: Connection, requestId: string, responseData: unknown) {
-	pcall(() => {
-		HttpService.RequestAsync({
-			Url: `${conn.serverUrl}/response`,
-			Method: "POST",
-			Headers: { "Content-Type": "application/json" },
-			Body: HttpService.JSONEncode({ requestId, response: responseData }),
+	const body = HttpService.JSONEncode({ requestId, response: responseData });
+	const maxAttempts = 3;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		const [ok, result] = pcall(() => {
+			return HttpService.RequestAsync({
+				Url: `${conn.serverUrl}/response`,
+				Method: "POST",
+				Headers: { "Content-Type": "application/json" },
+				Body: body,
+			});
 		});
-	});
+
+		if (ok && result.Success) return;
+
+		if (attempt < maxAttempts) {
+			task.wait(0.2 * attempt);
+		} else {
+			// Don't let a dropped response vanish silently into a 30s server-side
+			// timeout — make it visible in the Output window.
+			const reason = ok ? `HTTP ${result.StatusCode}` : tostring(result);
+			warn(`[robloxstudio-mcp] failed to deliver response for request ${requestId} after ${maxAttempts} attempts: ${reason}`);
+		}
+	}
+}
+
+interface HandledRequest {
+	status: "processing" | "done";
+	response?: unknown;
+}
+
+// Dedupe by requestId so a request the server re-dispatches (because a /response
+// was lost or it crossed the redispatch TTL while still running) is never
+// executed twice. While "processing" we ignore repeats; once "done" we re-send
+// the cached response instead of re-running the handler.
+const handledRequests = new Map<string, HandledRequest>();
+const handledOrder: string[] = [];
+const MAX_HANDLED_REQUESTS = 128;
+
+function rememberHandledRequest(requestId: string, entry: HandledRequest) {
+	if (!handledRequests.has(requestId)) {
+		handledOrder.push(requestId);
+		if (handledOrder.size() > MAX_HANDLED_REQUESTS) {
+			const oldest = handledOrder[0];
+			handledOrder.remove(0);
+			handledRequests.delete(oldest);
+		}
+	}
+	handledRequests.set(requestId, entry);
 }
 
 function getConnectionStatus(connIndex: number): string {
@@ -196,15 +237,35 @@ function pollForRequests(connIndex: number) {
 			}
 		}
 
-		if (data.request && mcpConnected) {
-			task.spawn(() => {
-				const [ok, response] = pcall(() => processRequest(data.request!));
-				if (ok) {
-					sendResponse(conn, data.requestId!, response);
-				} else {
-					sendResponse(conn, data.requestId!, { error: tostring(response) });
+		if (data.request && mcpConnected && data.requestId !== undefined) {
+			const requestId = data.requestId;
+			const existing = handledRequests.get(requestId);
+			if (existing) {
+				// Already seen this request id. If it finished, re-send the cached
+				// result (the server only re-offers a request when it never got the
+				// response). If it is still processing, the in-flight handler will
+				// post the response — do nothing. Spawn so retry waits never block
+				// the poll loop.
+				if (existing.status === "done") {
+					task.spawn(() => sendResponse(conn, requestId, existing.response));
 				}
-			});
+			} else {
+				rememberHandledRequest(requestId, { status: "processing" });
+				task.spawn(() => {
+					const [ok, response] = pcall(() => processRequest(data.request!));
+					const finalResponse = ok ? response : { error: tostring(response) };
+					rememberHandledRequest(requestId, { status: "done", response: finalResponse });
+					sendResponse(conn, requestId, finalResponse);
+				});
+			}
+		}
+
+		// Adaptive poll cadence: poll quickly while work is flowing, back off when
+		// idle so steady-state HTTP volume stays well under Roblox's rate limit.
+		if (data.request) {
+			conn.currentPollInterval = conn.pollInterval;
+		} else {
+			conn.currentPollInterval = math.min(conn.currentPollInterval * 1.5, conn.maxIdlePollInterval);
 		}
 	} else if (conn.isActive) {
 		conn.consecutiveFailures++;
@@ -287,6 +348,7 @@ function activatePlugin(connIndex?: number) {
 	conn.isActive = true;
 	conn.consecutiveFailures = 0;
 	conn.currentRetryDelay = 0.5;
+	conn.currentPollInterval = conn.pollInterval;
 	ui.screenGui.Enabled = true;
 
 	if (idx === State.getActiveTabIndex()) {
@@ -302,7 +364,7 @@ function activatePlugin(connIndex?: number) {
 		if (!conn.heartbeatConnection) {
 			conn.heartbeatConnection = RunService.Heartbeat.Connect(() => {
 				const now = tick();
-				const currentInterval = conn.consecutiveFailures > 5 ? conn.currentRetryDelay : conn.pollInterval;
+				const currentInterval = conn.consecutiveFailures > 5 ? conn.currentRetryDelay : conn.currentPollInterval;
 				if (now - conn.lastPoll > currentInterval) {
 					conn.lastPoll = now;
 					pollForRequests(idx);

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -147,15 +147,27 @@ const handledOrder: string[] = [];
 const MAX_HANDLED_REQUESTS = 128;
 
 function rememberHandledRequest(requestId: string, entry: HandledRequest) {
-	if (!handledRequests.has(requestId)) {
-		handledOrder.push(requestId);
-		if (handledOrder.size() > MAX_HANDLED_REQUESTS) {
-			const oldest = handledOrder[0];
-			handledOrder.remove(0);
-			handledRequests.delete(oldest);
+	const isNew = !handledRequests.has(requestId);
+	handledRequests.set(requestId, entry);
+	if (!isNew) return;
+
+	handledOrder.push(requestId);
+	if (handledOrder.size() <= MAX_HANDLED_REQUESTS) return;
+
+	// Over capacity: evict the oldest *completed* entry only. Never drop an
+	// in-flight ("processing") id — the server may still re-dispatch it, and
+	// losing the record here would let the handler run a second time. If the
+	// whole window is still processing (pathological), allow a brief overflow
+	// rather than risk a duplicate execution.
+	for (let i = 0; i < handledOrder.size(); i++) {
+		const id = handledOrder[i];
+		const existing = handledRequests.get(id);
+		if (!existing || existing.status === "done") {
+			handledOrder.remove(i);
+			handledRequests.delete(id);
+			break;
 		}
 	}
-	handledRequests.set(requestId, entry);
 }
 
 function getConnectionStatus(connIndex: number): string {

--- a/studio-plugin/src/modules/State.ts
+++ b/studio-plugin/src/modules/State.ts
@@ -11,6 +11,8 @@ function createConnection(port: number): Connection {
 		serverUrl: `http://localhost:${port}`,
 		isActive: false,
 		pollInterval: 0.5,
+		maxIdlePollInterval: 2.0,
+		currentPollInterval: 0.5,
 		lastPoll: 0,
 		consecutiveFailures: 0,
 		maxFailuresBeforeError: 50,

--- a/studio-plugin/src/types/index.d.ts
+++ b/studio-plugin/src/types/index.d.ts
@@ -5,6 +5,8 @@ export interface Connection {
 	serverUrl: string;
 	isActive: boolean;
 	pollInterval: number;
+	maxIdlePollInterval: number;
+	currentPollInterval: number;
 	lastPoll: number;
 	consecutiveFailures: number;
 	maxFailuresBeforeError: number;


### PR DESCRIPTION
## Problem

The HTTP poll-bridge between the MCP server and the Studio plugin dropped connections frequently under real agent usage — worst with parallel tool calls and multiple simultaneous agents (mid-session disconnects/timeouts).

## Root causes & fixes

**1. Double-dispatch race (core).** `BridgeService.getPendingRequest()` returned the oldest pending request but never marked it claimed, while the plugin polls every 0.5s. Any request slower than the poll interval was handed out again on the next poll (and the next…) — duplicate mutations plus a storm of `/response` posts. Requests now carry an in-flight `dispatchedAt`; one is only re-offered after a 10s redispatch TTL (lost-response recovery).

**2. Head-of-line starvation (core).** The same "return oldest, never claim" logic meant parallel/multi-agent requests starved behind the oldest in-flight one. Polls now serve the oldest *undispatched* request.

**3. Plugin requestId idempotency (plugin).** The plugin dedups by `requestId`: while `processing` it ignores repeats; once `done` it re-sends the *cached* response. This makes the server redispatch TTL safe — a re-dispatch can never re-execute side effects.

**4. Multi-agent port fragmentation (core).** Extra agents walked to their own ports (58742+) that the plugin never polls, so their calls dead-ended in 30s timeouts. Primary now binds the base port only; if it's taken, the agent enters proxy mode and forwards to the primary via the existing `ProxyBridgeService`, so every agent shares the one plugin connection. **This is the one behavioral change worth a careful look.**

**5. Silent response drops (plugin).** `sendResponse` swallowed failures in a bare `pcall` — a dropped post became an invisible 30s timeout. It now retries 3× and `warn()`s to Output.

**6. Adaptive polling (plugin).** 0.5s while work flows, backing off to 2s when idle, to keep HTTP volume well under Roblox's rate limit. I deliberately chose this over a server-held long-poll: `RequestAsync`'s default timeout is undocumented and its `Timeout` field can only *shorten* requests, so holding `/poll` open risks turning every hold into a plugin-side failure. Happy to revisit if you'd prefer long-poll.

## Also included

- Regenerated `MCPPlugin.rbxmx` / `MCPInspectorPlugin.rbxmx` — large diff, but tracked build output that must match the source changes.
- Version bump to **2.7.1** across packages + README.
- Repaired the broken `.eslintrc.json` (`@typescript-eslint/recommended` → `plugin:@typescript-eslint/recommended`) and the two pre-existing lint errors it surfaced, so `npm run lint` passes.

## Validation

- New `BridgeService` unit tests cover in-flight dispatch, no-starvation, and TTL re-dispatch (written test-first).
- Full suite **39/39 green**, typecheck clean, lint clean.
- **Validated in live Studio use** — a real multi-call agent session ran with zero disconnects/timeouts (vs. frequent drops before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the MCP↔Studio HTTP bridge under parallel tool calls and multi‑agent runs by making dispatch idempotent and fair, and by funneling all agents through one plugin connection. Tightens port‑in‑use detection, hardens plugin dedupe, adds adaptive polling, and ships v2.7.1.

- **Bug Fixes**
  - Core dispatch: track in‑flight with a 10s redispatch TTL; serve the oldest undispatched request, only then TTL‑expired ones (prevents duplicates and starvation).
  - Plugin: requestId dedupe with a bounded cache that evicts only completed entries; resend cached result on repeats; retry `/response` up to 3× and warn.
  - Server: bind the base port only; fall back to proxy mode only when `isPortInUseError` is true (EADDRINUSE or the aggregate “All ports … are in use”); `listenWithRetry` exhaustion sets `EADDRINUSE`.
  - Adaptive polling: 0.5s while active, backing off to 2s when idle.
  - Tests/misc: add `BridgeService` and `isPortInUseError` tests; uptime check made non‑negative.

- **Dependencies**
  - Bump to `2.7.1` for `robloxstudio-mcp`, `robloxstudio-mcp-inspector`, `@robloxstudio-mcp/core`; regenerate `MCPPlugin.rbxmx` and `MCPInspectorPlugin.rbxmx`; fix ESLint extends to `plugin:@typescript-eslint/recommended`; update README version.

<sup>Written for commit 37c65ec20aab2a025fbe1fc23a596f4691c85609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/boshyxd/robloxstudio-mcp/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive polling cadence per-connection (faster with work, backs off when idle).
  * In-flight request tracking with redispatch timeout.
  * Depth-first descendant traversal utility to improve search performance.

* **Bug Fixes**
  * Response delivery retries (up to 3 attempts) with backoff and warnings.
  * Request deduplication to avoid duplicate handling.
  * HTTP binding only falls back to proxy mode for genuine port-in-use errors.

* **Tests**
  * Added coverage for in-flight dispatch and port/uptime behaviors.

* **Chores**
  * Version bumped to 2.7.1 and README metadata updated.

* **Style**
  * ESLint extends identifier aligned with plugin naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->