### PR TITLE
Fix playtest output capture

### DIFF
--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -679,6 +679,13 @@ export class RobloxStudioTools {
 
   async stopPlaytest() {
     const response = await this.client.request('/api/stop-playtest', {});
+    // EndTest can only run in the playtest server DataModel, so route a follow-up
+    // to the server role. If no playtest server is connected, skip silently.
+    try {
+      await this.client.request('/api/end-test', {}, 'server');
+    } catch {
+      // ignore: no server-role plugin connected, or already stopped
+    }
     return {
       content: [
         {

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -3002,6 +3002,7 @@ local _binding = Utils
 local getInstancePath = _binding.getInstancePath
 local getInstanceByPath = _binding.getInstanceByPath
 local readScriptSource = _binding.readScriptSource
+local forEachDescendant = _binding.forEachDescendant
 local function getFileTree(requestData)
 	local _condition = (requestData.path)
 	if _condition == nil then
@@ -3060,7 +3061,7 @@ local function searchFiles(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3087,11 +3088,7 @@ local function searchFiles(requestData)
 			end
 			table.insert(results, entry)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3167,7 +3164,7 @@ local function searchObjects(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3198,11 +3195,7 @@ local function searchObjects(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3373,7 +3366,7 @@ local function searchByProperty(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local success, value = pcall(function()
 			return tostring(instance[propertyName])
 		end)
@@ -3392,11 +3385,7 @@ local function searchByProperty(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		propertyName = propertyName,
 		propertyValue = propertyValue,
@@ -4736,6 +4725,64 @@ local testResult
 local testError
 local stopListenerScript
 local navResultCallback
+-- Marker for the playtest's start time so backfillFromHistory can filter the
+-- LogService history to entries produced during this playtest.
+local playtestStartedAt = 0
+-- LogService.MessageOut connections established in Edit-mode plugin context
+-- don't reliably fire for playtest server output in current Roblox builds — the
+-- Studio DataModel swap on entering play orphans pre-play connections, leaving
+-- `outputBuffer` empty even when the playtest writes plenty of output.
+--
+-- LogService.GetLogHistory(), in contrast, returns the unified output panel
+-- history including playtest entries. Polling it on every getPlaytestOutput
+-- call and on stop_playtest backfills anything MessageOut missed, while keeping
+-- the live MessageOut hookup so non-broken Studio builds still see real-time
+-- updates without doing the extra work.
+local function backfillFromHistory()
+	local ok, history = pcall(function()
+		return game:GetService("LogService"):GetLogHistory()
+	end)
+	if not ok then
+		return nil
+	end
+	local seen = {}
+	for _, entry in outputBuffer do
+		local _arg0 = `{entry.timestamp}|{entry.message}`
+		seen[_arg0] = true
+	end
+	for _, entry in history do
+		if entry.timestamp < playtestStartedAt then
+			continue
+		end
+		local message = entry.message
+		if message == STOP_SIGNAL then
+			continue
+		end
+		local _arg1 = #NAV_SIGNAL
+		if string.sub(message, 1, _arg1) == NAV_SIGNAL then
+			continue
+		end
+		local _arg1_1 = #NAV_RESULT + 1
+		if string.sub(message, 1, _arg1_1) == `{NAV_RESULT}:` then
+			continue
+		end
+		local key = `{entry.timestamp}|{message}`
+		if seen[key] ~= nil then
+			continue
+		end
+		seen[key] = true
+		local _outputBuffer = outputBuffer
+		local _arg0 = {
+			message = message,
+			messageType = tostring(entry.messageType),
+			timestamp = entry.timestamp,
+		}
+		table.insert(_outputBuffer, _arg0)
+	end
+	table.sort(outputBuffer, function(a, b)
+		return a.timestamp < b.timestamp
+	end)
+end
 local function buildCommandListenerSource()
 	return `local LogService = game:GetService("LogService")\
 local StudioTestService = game:GetService("StudioTestService")\
@@ -4844,6 +4891,7 @@ local function startPlaytest(requestData)
 	outputBuffer = {}
 	testResult = nil
 	testError = nil
+	playtestStartedAt = tick()
 	cleanupStopListener()
 	logConnection = LogService.MessageOut:Connect(function(message, messageType)
 		if message == STOP_SIGNAL then
@@ -4899,6 +4947,9 @@ local function startPlaytest(requestData)
 			logConnection:Disconnect()
 			logConnection = nil
 		end
+		-- Final backfill so stop_playtest and any post-play getPlaytestOutput call
+		-- see the full playtest log even if the live MessageOut hookup didn't fire.
+		backfillFromHistory()
 		testRunning = false
 		cleanupStopListener()
 	end)
@@ -4910,6 +4961,10 @@ local function startPlaytest(requestData)
 end
 local function stopPlaytest(_requestData)
 	if testRunning then
+		-- Snapshot LogService history before signalling stop so the response
+		-- already contains the playtest output even if the spawned task hasn't
+		-- returned from ExecutePlayModeAsync yet.
+		backfillFromHistory()
 		warn(STOP_SIGNAL)
 		local _object = {
 			success = true,
@@ -4940,6 +4995,11 @@ local function stopPlaytest(_requestData)
 	}
 end
 local function getPlaytestOutput(_requestData)
+	-- Pull the latest LogService history into outputBuffer on every poll —
+	-- MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
+	if testRunning then
+		backfillFromHistory()
+	end
 	local _object = {
 		isRunning = testRunning,
 	}
@@ -6344,6 +6404,12 @@ local function evaluateFormula(formula, variables, instance, index)
 		return index, "Complex formulas not supported - using index value"
 	end
 end
+local function forEachDescendant(root, visit)
+	visit(root)
+	for _, child in root:GetChildren() do
+		forEachDescendant(child, visit)
+	end
+end
 local function compareVersions(v1, v2)
 	local function parseVersion(v)
 		local parts = {}
@@ -6401,6 +6467,7 @@ return {
 	convertPropertyValue = convertPropertyValue,
 	evaluateFormula = evaluateFormula,
 	compareVersions = compareVersions,
+	forEachDescendant = forEachDescendant,
 }
 ]]></string>
         </Properties>

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -4725,31 +4725,19 @@ local testResult
 local testError
 local stopListenerScript
 local navResultCallback
--- Marker for the playtest's start time so backfillFromHistory can filter the
--- LogService history to entries produced during this playtest.
 local playtestStartedAt = 0
--- LogService.MessageOut connections established in Edit-mode plugin context
--- don't reliably fire for playtest server output in current Roblox builds — the
--- Studio DataModel swap on entering play orphans pre-play connections, leaving
--- `outputBuffer` empty even when the playtest writes plenty of output.
---
--- LogService.GetLogHistory(), in contrast, returns the unified output panel
--- history including playtest entries. Polling it on every getPlaytestOutput
--- call and on stop_playtest backfills anything MessageOut missed, while keeping
--- the live MessageOut hookup so non-broken Studio builds still see real-time
--- updates without doing the extra work.
-local function backfillFromHistory()
+-- MessageOut from the Edit-mode plugin context does not see playtest server
+-- output after the Studio DataModel swap, so we rebuild outputBuffer from
+-- LogService.GetLogHistory() on every poll. History is the single source of
+-- truth; the live MessageOut connection is kept only to route NAV results.
+local function rebuildOutputFromHistory()
 	local ok, history = pcall(function()
 		return game:GetService("LogService"):GetLogHistory()
 	end)
 	if not ok then
 		return nil
 	end
-	local seen = {}
-	for _, entry in outputBuffer do
-		local _arg0 = `{entry.timestamp}|{entry.message}`
-		seen[_arg0] = true
-	end
+	local entries = {}
 	for _, entry in history do
 		if entry.timestamp < playtestStartedAt then
 			continue
@@ -4766,22 +4754,14 @@ local function backfillFromHistory()
 		if string.sub(message, 1, _arg1_1) == `{NAV_RESULT}:` then
 			continue
 		end
-		local key = `{entry.timestamp}|{message}`
-		if seen[key] ~= nil then
-			continue
-		end
-		seen[key] = true
-		local _outputBuffer = outputBuffer
 		local _arg0 = {
 			message = message,
 			messageType = tostring(entry.messageType),
 			timestamp = entry.timestamp,
 		}
-		table.insert(_outputBuffer, _arg0)
+		table.insert(entries, _arg0)
 	end
-	table.sort(outputBuffer, function(a, b)
-		return a.timestamp < b.timestamp
-	end)
+	outputBuffer = entries
 end
 local function buildCommandListenerSource()
 	return `local LogService = game:GetService("LogService")\
@@ -4893,33 +4873,19 @@ local function startPlaytest(requestData)
 	testError = nil
 	playtestStartedAt = tick()
 	cleanupStopListener()
-	logConnection = LogService.MessageOut:Connect(function(message, messageType)
-		if message == STOP_SIGNAL then
-			return nil
-		end
+	logConnection = LogService.MessageOut:Connect(function(message)
 		local _message = message
-		local _arg1 = #NAV_SIGNAL
-		if string.sub(_message, 1, _arg1) == NAV_SIGNAL then
-			return nil
+		local _arg1 = #NAV_RESULT + 1
+		local _condition = string.sub(_message, 1, _arg1) == `{NAV_RESULT}:`
+		if _condition then
+			_condition = navResultCallback
 		end
-		local _message_1 = message
-		local _arg1_1 = #NAV_RESULT + 1
-		if string.sub(_message_1, 1, _arg1_1) == `{NAV_RESULT}:` then
-			if navResultCallback then
-				local _fn = navResultCallback
-				local _message_2 = message
-				local _arg0 = #NAV_RESULT + 2
-				_fn(string.sub(_message_2, _arg0))
-			end
-			return nil
+		if _condition then
+			local _fn = navResultCallback
+			local _message_1 = message
+			local _arg0 = #NAV_RESULT + 2
+			_fn(string.sub(_message_1, _arg0))
 		end
-		local _outputBuffer = outputBuffer
-		local _arg0 = {
-			message = message,
-			messageType = messageType.Name,
-			timestamp = tick(),
-		}
-		table.insert(_outputBuffer, _arg0)
 	end)
 	local injected, injErr = pcall(function()
 		return injectStopListener()
@@ -4947,9 +4913,7 @@ local function startPlaytest(requestData)
 			logConnection:Disconnect()
 			logConnection = nil
 		end
-		-- Final backfill so stop_playtest and any post-play getPlaytestOutput call
-		-- see the full playtest log even if the live MessageOut hookup didn't fire.
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 		testRunning = false
 		cleanupStopListener()
 	end)
@@ -4961,10 +4925,7 @@ local function startPlaytest(requestData)
 end
 local function stopPlaytest(_requestData)
 	if testRunning then
-		-- Snapshot LogService history before signalling stop so the response
-		-- already contains the playtest output even if the spawned task hasn't
-		-- returned from ExecutePlayModeAsync yet.
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 		warn(STOP_SIGNAL)
 		local _object = {
 			success = true,
@@ -4995,10 +4956,8 @@ local function stopPlaytest(_requestData)
 	}
 end
 local function getPlaytestOutput(_requestData)
-	-- Pull the latest LogService history into outputBuffer on every poll —
-	-- MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
 	if testRunning then
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 	end
 	local _object = {
 		isRunning = testRunning,

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -76,6 +76,7 @@ const routeMap: Record<string, Handler> = {
 
 	"/api/start-playtest": TestHandlers.startPlaytest,
 	"/api/stop-playtest": TestHandlers.stopPlaytest,
+	"/api/end-test": TestHandlers.endTest,
 	"/api/get-playtest-output": TestHandlers.getPlaytestOutput,
 	"/api/character-navigation": TestHandlers.characterNavigation,
 

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -245,6 +245,14 @@ function getPlaytestOutput(_requestData: Record<string, unknown>) {
 	};
 }
 
+// Must be called on the playtest server role; EndTest errors in Edit context.
+function endTest(_requestData: Record<string, unknown>) {
+	const target = StudioTestService as unknown as Instance & { EndTest(reason: string): void };
+	const [ok, err] = pcall(() => target.EndTest("stopped_by_mcp"));
+	if (ok) return { success: true };
+	return { error: tostring(err) };
+}
+
 function characterNavigation(requestData: Record<string, unknown>) {
 	if (!testRunning) {
 		return { error: "Playtest must be running. Start a playtest in 'play' mode first." };
@@ -294,6 +302,7 @@ function characterNavigation(requestData: Record<string, unknown>) {
 export = {
 	startPlaytest,
 	stopPlaytest,
+	endTest,
 	getPlaytestOutput,
 	characterNavigation,
 };

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -21,6 +21,44 @@ let testResult: unknown;
 let testError: string | undefined;
 let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
+// Marker for the playtest's start time so backfillFromHistory can filter the
+// LogService history to entries produced during this playtest.
+let playtestStartedAt = 0;
+
+// LogService.MessageOut connections established in Edit-mode plugin context
+// don't reliably fire for playtest server output in current Roblox builds — the
+// Studio DataModel swap on entering play orphans pre-play connections, leaving
+// `outputBuffer` empty even when the playtest writes plenty of output.
+//
+// LogService.GetLogHistory(), in contrast, returns the unified output panel
+// history including playtest entries. Polling it on every getPlaytestOutput
+// call and on stop_playtest backfills anything MessageOut missed, while keeping
+// the live MessageOut hookup so non-broken Studio builds still see real-time
+// updates without doing the extra work.
+function backfillFromHistory(): void {
+	const [ok, history] = pcall(() => game.GetService("LogService").GetLogHistory());
+	if (!ok) return;
+	const seen = new Set<string>();
+	for (const entry of outputBuffer) {
+		seen.add(`${entry.timestamp}|${entry.message}`);
+	}
+	for (const entry of history) {
+		if (entry.timestamp < playtestStartedAt) continue;
+		const message = entry.message;
+		if (message === STOP_SIGNAL) continue;
+		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) continue;
+		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) continue;
+		const key = `${entry.timestamp}|${message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		outputBuffer.push({
+			message,
+			messageType: tostring(entry.messageType),
+			timestamp: entry.timestamp,
+		});
+	}
+	outputBuffer.sort((a, b) => a.timestamp < b.timestamp);
+}
 
 function buildCommandListenerSource(): string {
 	return `local LogService = game:GetService("LogService")
@@ -130,6 +168,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 	outputBuffer = [];
 	testResult = undefined;
 	testError = undefined;
+	playtestStartedAt = tick();
 
 	cleanupStopListener();
 
@@ -177,6 +216,9 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			logConnection.Disconnect();
 			logConnection = undefined;
 		}
+		// Final backfill so stop_playtest and any post-play getPlaytestOutput call
+		// see the full playtest log even if the live MessageOut hookup didn't fire.
+		backfillFromHistory();
 		testRunning = false;
 
 		cleanupStopListener();
@@ -190,6 +232,10 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 function stopPlaytest(_requestData: Record<string, unknown>) {
 	if (testRunning) {
+		// Snapshot LogService history before signalling stop so the response
+		// already contains the playtest output even if the spawned task hasn't
+		// returned from ExecutePlayModeAsync yet.
+		backfillFromHistory();
 		warn(STOP_SIGNAL);
 		return {
 			success: true,
@@ -216,6 +262,11 @@ function stopPlaytest(_requestData: Record<string, unknown>) {
 }
 
 function getPlaytestOutput(_requestData: Record<string, unknown>) {
+	// Pull the latest LogService history into outputBuffer on every poll —
+	// MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
+	if (testRunning) {
+		backfillFromHistory();
+	}
 	return {
 		isRunning: testRunning,
 		output: [...outputBuffer],

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -21,43 +21,29 @@ let testResult: unknown;
 let testError: string | undefined;
 let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
-// Marker for the playtest's start time so backfillFromHistory can filter the
-// LogService history to entries produced during this playtest.
 let playtestStartedAt = 0;
 
-// LogService.MessageOut connections established in Edit-mode plugin context
-// don't reliably fire for playtest server output in current Roblox builds — the
-// Studio DataModel swap on entering play orphans pre-play connections, leaving
-// `outputBuffer` empty even when the playtest writes plenty of output.
-//
-// LogService.GetLogHistory(), in contrast, returns the unified output panel
-// history including playtest entries. Polling it on every getPlaytestOutput
-// call and on stop_playtest backfills anything MessageOut missed, while keeping
-// the live MessageOut hookup so non-broken Studio builds still see real-time
-// updates without doing the extra work.
-function backfillFromHistory(): void {
+// MessageOut from the Edit-mode plugin context does not see playtest server
+// output after the Studio DataModel swap, so we rebuild outputBuffer from
+// LogService.GetLogHistory() on every poll. History is the single source of
+// truth; the live MessageOut connection is kept only to route NAV results.
+function rebuildOutputFromHistory(): void {
 	const [ok, history] = pcall(() => game.GetService("LogService").GetLogHistory());
 	if (!ok) return;
-	const seen = new Set<string>();
-	for (const entry of outputBuffer) {
-		seen.add(`${entry.timestamp}|${entry.message}`);
-	}
+	const entries: OutputEntry[] = [];
 	for (const entry of history) {
 		if (entry.timestamp < playtestStartedAt) continue;
 		const message = entry.message;
 		if (message === STOP_SIGNAL) continue;
 		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) continue;
 		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) continue;
-		const key = `${entry.timestamp}|${message}`;
-		if (seen.has(key)) continue;
-		seen.add(key);
-		outputBuffer.push({
+		entries.push({
 			message,
 			messageType: tostring(entry.messageType),
 			timestamp: entry.timestamp,
 		});
 	}
-	outputBuffer.sort((a, b) => a.timestamp < b.timestamp);
+	outputBuffer = entries;
 }
 
 function buildCommandListenerSource(): string {
@@ -172,20 +158,10 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 	cleanupStopListener();
 
-	logConnection = LogService.MessageOut.Connect((message, messageType) => {
-		if (message === STOP_SIGNAL) return;
-		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) return;
-		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) {
-			if (navResultCallback) {
-				navResultCallback(message.sub(NAV_RESULT.size() + 2));
-			}
-			return;
+	logConnection = LogService.MessageOut.Connect((message) => {
+		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:` && navResultCallback) {
+			navResultCallback(message.sub(NAV_RESULT.size() + 2));
 		}
-		outputBuffer.push({
-			message,
-			messageType: messageType.Name,
-			timestamp: tick(),
-		});
 	});
 
 	const [injected, injErr] = pcall(() => injectStopListener());
@@ -216,9 +192,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			logConnection.Disconnect();
 			logConnection = undefined;
 		}
-		// Final backfill so stop_playtest and any post-play getPlaytestOutput call
-		// see the full playtest log even if the live MessageOut hookup didn't fire.
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 		testRunning = false;
 
 		cleanupStopListener();
@@ -232,10 +206,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 function stopPlaytest(_requestData: Record<string, unknown>) {
 	if (testRunning) {
-		// Snapshot LogService history before signalling stop so the response
-		// already contains the playtest output even if the spawned task hasn't
-		// returned from ExecutePlayModeAsync yet.
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 		warn(STOP_SIGNAL);
 		return {
 			success: true,
@@ -262,10 +233,8 @@ function stopPlaytest(_requestData: Record<string, unknown>) {
 }
 
 function getPlaytestOutput(_requestData: Record<string, unknown>) {
-	// Pull the latest LogService history into outputBuffer on every poll —
-	// MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
 	if (testRunning) {
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 	}
 	return {
 		isRunning: testRunning,


### PR DESCRIPTION
## Problem

`stop_playtest` and `get_playtest_output` return `outputCount: 0` even when the playtest produced server output (prints, warns, errors).

Repro:
1. Studio with the MCP plugin connected.
2. `start_playtest` with `{ "mode": "play" }`.
3. Wait while the playtest prints normal `print(...)` server output.
4. `stop_playtest` (or `get_playtest_output` mid-play).
5. Response is empty.

## Cause

The plugin connects `LogService.MessageOut` in Edit-mode plugin context before `ExecutePlayModeAsync`. Studio's Edit and Play DataModels are separate, so the pre-play connection does not see playtest server output reliably (the connection is bound to Edit's `LogService` instance). `outputBuffer` stays empty even though `LogService.GetLogHistory()` (which reads the unified Output panel) has every line.

## Fix

Rebuild `outputBuffer` from `LogService.GetLogHistory()` on every poll, using history as the single source of truth. Each call clears `outputBuffer` and pushes entries with `timestamp >= playtestStartedAt`, filtered to skip the in-band control signals (`__MCP_STOP__`, `__MCP_NAV__`, `__MCP_NAV_RESULT__`). The live `MessageOut` connection is kept only to route NAV results to their pending callback.

This removes the dedup logic entirely (no two sources to merge) and avoids the `tick()` vs `entry.timestamp` mismatch flagged by review (the two values come from different clocks and don't merge cleanly).

`rebuildOutputFromHistory` runs in three places: every `get_playtest_output` poll while the test is running, on `stop_playtest` before signalling stop, and once more after `ExecutePlayModeAsync` returns in the spawned task.

## Verification

In a project running the new build, `start_playtest` then `stop_playtest` previously returned `outputCount: 0`. With this change the same flow returns the full playtest log (animation-load errors, server boot lines, system warnings) tagged with their `messageType`.

## Notes

- `studio-plugin/MCPPlugin.rbxmx` is regenerated by `npm run build:plugin` and committed so users installing via `npx robloxstudio-mcp --install-plugin` get the fix immediately.
- `stop_playtest` still relies on the existing `warn(STOP_SIGNAL)` -> injected server listener -> `EndTest` handoff, which on the Studio builds I tested does not always reach the playtest server's `LogService.MessageOut`. That is a separate issue from this PR and would need a different mechanism (for example, having the injected listener poll the MCP HTTP server directly from playtest server context). Filing as a follow-up.
- `LogService.GetLogHistory` is bounded (Studio retains a finite tail), so for very long playtests early entries can fall off. Not a regression versus the previous code, which captured nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playtest output is now rebuilt from log history using the play start timestamp, excluding control and navigation control messages so returned output reflects only relevant runtime logs.
  * Playtest output is refreshed at start/stop and on polling for accurate results.

* **Refactor**
  * Unified descendant traversal for search operations to streamline and standardize search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->