### PR TITLE
Fix playtest output capture and stop

### DIFF
--- a/packages/core/src/bridge-service.ts
+++ b/packages/core/src/bridge-service.ts
@@ -20,11 +20,55 @@ interface PendingRequest {
 
 const STALE_INSTANCE_MS = 30000;
 
+export interface PlaytestOutputEntry {
+  message: string;
+  messageType: string;
+  timestamp: number;
+}
+
 export class BridgeService {
   private pendingRequests: Map<string, PendingRequest> = new Map();
   private instances: Map<string, PluginInstance> = new Map();
   private nextClientIndex = 1;
   private requestTimeout = 30000;
+
+  private playtestActive = false;
+  private playtestBuffer: PlaytestOutputEntry[] = [];
+  private playtestStopRequested = false;
+
+  resetPlaytest() {
+    this.playtestBuffer = [];
+    this.playtestStopRequested = false;
+    this.playtestActive = true;
+  }
+
+  endPlaytest() {
+    this.playtestActive = false;
+    this.playtestStopRequested = false;
+  }
+
+  pushPlaytestOutput(entries: PlaytestOutputEntry[]) {
+    if (!this.playtestActive) return;
+    for (const entry of entries) {
+      this.playtestBuffer.push(entry);
+    }
+  }
+
+  getPlaytestBuffer(): PlaytestOutputEntry[] {
+    return [...this.playtestBuffer];
+  }
+
+  requestPlaytestStop() {
+    if (this.playtestActive) this.playtestStopRequested = true;
+  }
+
+  isPlaytestStopRequested(): boolean {
+    return this.playtestActive && this.playtestStopRequested;
+  }
+
+  isPlaytestActive(): boolean {
+    return this.playtestActive;
+  }
 
   registerInstance(instanceId: string, role: string): string {
     let assignedRole = role;

--- a/packages/core/src/http-server.ts
+++ b/packages/core/src/http-server.ts
@@ -267,6 +267,28 @@ export function createHttpServer(tools: RobloxStudioTools, bridge: BridgeService
   });
 
 
+  app.post('/playtest/output', (req, res) => {
+    const entries = req.body?.entries;
+    if (!Array.isArray(entries)) {
+      res.status(400).json({ error: 'entries must be an array' });
+      return;
+    }
+    bridge.pushPlaytestOutput(entries);
+    res.json({ success: true });
+  });
+
+
+  app.get('/playtest/command', (req, res) => {
+    res.json({ stop: bridge.isPlaytestStopRequested() });
+  });
+
+
+  app.post('/playtest/end', (req, res) => {
+    bridge.endPlaytest();
+    res.json({ success: true });
+  });
+
+
   app.post('/proxy', async (req, res) => {
     const { endpoint, data, target, proxyInstanceId } = req.body;
 

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -662,12 +662,14 @@ export class RobloxStudioTools {
     if (mode !== 'play' && mode !== 'run') {
       throw new Error('mode must be "play" or "run"');
     }
-    this.bridge.resetPlaytest();
     const data: Record<string, unknown> = { mode };
     if (numPlayers !== undefined) {
       data.numPlayers = numPlayers;
     }
     const response = await this.client.request('/api/start-playtest', data);
+    if (response?.success) {
+      this.bridge.resetPlaytest();
+    }
     return {
       content: [
         {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -679,6 +679,13 @@ export class RobloxStudioTools {
 
   async stopPlaytest() {
     const response = await this.client.request('/api/stop-playtest', {});
+    // EndTest can only run in the playtest server DataModel, so route a follow-up
+    // to the server role. If no playtest server is connected, skip silently.
+    try {
+      await this.client.request('/api/end-test', {}, 'server');
+    } catch {
+      // ignore: no server-role plugin connected, or already stopped
+    }
     return {
       content: [
         {

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -662,6 +662,7 @@ export class RobloxStudioTools {
     if (mode !== 'play' && mode !== 'run') {
       throw new Error('mode must be "play" or "run"');
     }
+    this.bridge.resetPlaytest();
     const data: Record<string, unknown> = { mode };
     if (numPlayers !== undefined) {
       data.numPlayers = numPlayers;
@@ -678,31 +679,35 @@ export class RobloxStudioTools {
   }
 
   async stopPlaytest() {
-    const response = await this.client.request('/api/stop-playtest', {});
-    // EndTest can only run in the playtest server DataModel, so route a follow-up
-    // to the server role. If no playtest server is connected, skip silently.
-    try {
-      await this.client.request('/api/end-test', {}, 'server');
-    } catch {
-      // ignore: no server-role plugin connected, or already stopped
-    }
+    this.bridge.requestPlaytestStop();
+    const buffer = this.bridge.getPlaytestBuffer();
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(response)
+          text: JSON.stringify({
+            success: true,
+            isRunning: this.bridge.isPlaytestActive(),
+            output: buffer,
+            outputCount: buffer.length,
+            message: 'Stop requested; injected listener will call EndTest on its next poll.',
+          })
         }
       ]
     };
   }
 
-  async getPlaytestOutput(target?: string) {
-    const response = await this.client.request('/api/get-playtest-output', {}, target || 'edit');
+  async getPlaytestOutput(_target?: string) {
+    const buffer = this.bridge.getPlaytestBuffer();
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(response)
+          text: JSON.stringify({
+            isRunning: this.bridge.isPlaytestActive(),
+            output: buffer,
+            outputCount: buffer.length,
+          })
         }
       ]
     };

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -111,8 +111,6 @@ local routeMap = {
 	["/api/redo"] = MetadataHandlers.redo,
 	["/api/bulk-set-attributes"] = MetadataHandlers.bulkSetAttributes,
 	["/api/start-playtest"] = TestHandlers.startPlaytest,
-	["/api/stop-playtest"] = TestHandlers.stopPlaytest,
-	["/api/get-playtest-output"] = TestHandlers.getPlaytestOutput,
 	["/api/character-navigation"] = TestHandlers.characterNavigation,
 	["/api/export-build"] = BuildHandlers.exportBuild,
 	["/api/import-build"] = BuildHandlers.importBuild,
@@ -4712,69 +4710,82 @@ local TS = require(script.Parent.Parent.Parent.include.RuntimeLib)
 local _services = TS.import(script, script.Parent.Parent.Parent, "node_modules", "@rbxts", "services")
 local HttpService = _services.HttpService
 local LogService = _services.LogService
+local State = TS.import(script, script.Parent.Parent, "State")
 local StudioTestService = game:GetService("StudioTestService")
 local ServerScriptService = game:GetService("ServerScriptService")
 local ScriptEditorService = game:GetService("ScriptEditorService")
-local STOP_SIGNAL = "__MCP_STOP__"
 local NAV_SIGNAL = "__MCP_NAV__"
 local NAV_RESULT = "__MCP_NAV_RESULT__"
 local testRunning = false
-local outputBuffer = {}
-local logConnection
+local editNavConnection
 local testResult
 local testError
 local stopListenerScript
 local navResultCallback
-local playtestStartedAt = 0
--- MessageOut from the Edit-mode plugin context does not see playtest server
--- output after the Studio DataModel swap, so we rebuild outputBuffer from
--- LogService.GetLogHistory() on every poll. History is the single source of
--- truth; the live MessageOut connection is kept only to route NAV results.
-local function rebuildOutputFromHistory()
-	local ok, history = pcall(function()
-		return game:GetService("LogService"):GetLogHistory()
-	end)
-	if not ok then
-		return nil
-	end
-	local entries = {}
-	for _, entry in history do
-		if entry.timestamp < playtestStartedAt then
-			continue
-		end
-		local message = entry.message
-		if message == STOP_SIGNAL then
-			continue
-		end
-		local _arg1 = #NAV_SIGNAL
-		if string.sub(message, 1, _arg1) == NAV_SIGNAL then
-			continue
-		end
-		local _arg1_1 = #NAV_RESULT + 1
-		if string.sub(message, 1, _arg1_1) == `{NAV_RESULT}:` then
-			continue
-		end
-		local _arg0 = {
-			message = message,
-			messageType = tostring(entry.messageType),
-			timestamp = entry.timestamp,
-		}
-		table.insert(entries, _arg0)
-	end
-	outputBuffer = entries
-end
-local function buildCommandListenerSource()
+local function buildCommandListenerSource(baseUrl)
 	return `local LogService = game:GetService("LogService")\
 local StudioTestService = game:GetService("StudioTestService")\
 local PathfindingService = game:GetService("PathfindingService")\
 local Players = game:GetService("Players")\
 local HttpService = game:GetService("HttpService")\
+local BASE = "{baseUrl}"\
 local NAV_SIG = "{NAV_SIGNAL}"\
 local NAV_RES = "{NAV_RESULT}"\
+local OUTPUT_URL = BASE .. "/playtest/output"\
+local COMMAND_URL = BASE .. "/playtest/command"\
+\
+local pending = \{\}\
+LogService.MessageOut:Connect(function(msg, mt)\
+	if string.sub(msg, 1, #NAV_SIG) == NAV_SIG then return end\
+	if string.sub(msg, 1, #NAV_RES) == NAV_RES then return end\
+	table.insert(pending, \{\
+		message = msg,\
+		messageType = mt.Name,\
+		timestamp = tick(),\
+	\})\
+end)\
+\
+task.spawn(function()\
+	while true do\
+		task.wait(0.2)\
+		if #pending > 0 then\
+			local batch = pending\
+			pending = \{\}\
+			pcall(function()\
+				HttpService:RequestAsync(\{\
+					Url = OUTPUT_URL,\
+					Method = "POST",\
+					Headers = \{ ["Content-Type"] = "application/json" \},\
+					Body = HttpService:JSONEncode(\{ entries = batch \}),\
+				\})\
+			end)\
+		end\
+	end\
+end)\
+\
+task.spawn(function()\
+	while true do\
+		task.wait(0.5)\
+		local ok, response = pcall(function()\
+			return HttpService:RequestAsync(\{\
+				Url = COMMAND_URL,\
+				Method = "GET",\
+			\})\
+		end)\
+		if ok and response.Success and response.Body then\
+			local parsed\
+			local decodeOk\
+			decodeOk, parsed = pcall(function() return HttpService:JSONDecode(response.Body) end)\
+			if decodeOk and parsed and parsed.stop then\
+				pcall(function() StudioTestService:EndTest("stopped_by_mcp") end)\
+				return\
+			end\
+		end\
+	end\
+end)\
+\
 LogService.MessageOut:Connect(function(msg)\
-	if msg == "{STOP_SIGNAL}" then\
-		pcall(function() StudioTestService:EndTest("stopped_by_mcp") end)\
-	elseif string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then\
+	if string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then\
 		local json = string.sub(msg, #NAV_SIG + 2)\
 		task.spawn(function()\
 			local ok, d = pcall(function() return HttpService:JSONDecode(json) end)\
@@ -4831,11 +4842,11 @@ LogService.MessageOut:Connect(function(msg)\
 	end\
 end)`
 end
-local function injectStopListener()
+local function injectStopListener(baseUrl)
 	local listener = Instance.new("Script")
 	listener.Name = "__MCP_CommandListener"
 	listener.Parent = ServerScriptService
-	local source = buildCommandListenerSource()
+	local source = buildCommandListenerSource(baseUrl)
 	local seOk = pcall(function()
 		ScriptEditorService:UpdateSourceAsync(listener, function()
 			return source
@@ -4854,6 +4865,18 @@ local function cleanupStopListener()
 		stopListenerScript = nil
 	end
 end
+local function notifyPlaytestEnded(baseUrl)
+	pcall(function()
+		HttpService:RequestAsync({
+			Url = `{baseUrl}/playtest/end`,
+			Method = "POST",
+			Headers = {
+				["Content-Type"] = "application/json",
+			},
+			Body = "{}",
+		})
+	end)
+end
 local function startPlaytest(requestData)
 	local mode = requestData.mode
 	local numPlayers = requestData.numPlayers
@@ -4867,13 +4890,13 @@ local function startPlaytest(requestData)
 			error = "A test is already running",
 		}
 	end
+	local conn = State.getActiveConnection()
+	local baseUrl = conn.serverUrl
 	testRunning = true
-	outputBuffer = {}
 	testResult = nil
 	testError = nil
-	playtestStartedAt = tick()
 	cleanupStopListener()
-	logConnection = LogService.MessageOut:Connect(function(message)
+	editNavConnection = LogService.MessageOut:Connect(function(message)
 		local _message = message
 		local _arg1 = #NAV_RESULT + 1
 		local _condition = string.sub(_message, 1, _arg1) == `{NAV_RESULT}:`
@@ -4888,10 +4911,10 @@ local function startPlaytest(requestData)
 		end
 	end)
 	local injected, injErr = pcall(function()
-		return injectStopListener()
+		return injectStopListener(baseUrl)
 	end)
 	if not injected then
-		warn(`[MCP] Failed to inject stop listener: {injErr}`)
+		warn(`[MCP] Failed to inject playtest listener: {injErr}`)
 	end
 	if numPlayers ~= nil and mode == "run" then
 		local TestService = game:GetService("TestService")
@@ -4909,12 +4932,12 @@ local function startPlaytest(requestData)
 		else
 			testError = tostring(result)
 		end
-		if logConnection then
-			logConnection:Disconnect()
-			logConnection = nil
+		if editNavConnection then
+			editNavConnection:Disconnect()
+			editNavConnection = nil
 		end
-		rebuildOutputFromHistory()
 		testRunning = false
+		notifyPlaytestEnded(baseUrl)
 		cleanupStopListener()
 	end)
 	local msg = if numPlayers ~= nil then `Playtest started in {mode} mode with {numPlayers} player(s)` else `Playtest started in {mode} mode`
@@ -4922,55 +4945,6 @@ local function startPlaytest(requestData)
 		success = true,
 		message = msg,
 	}
-end
-local function stopPlaytest(_requestData)
-	if testRunning then
-		rebuildOutputFromHistory()
-		warn(STOP_SIGNAL)
-		local _object = {
-			success = true,
-		}
-		local _left = "output"
-		local _array = {}
-		local _length = #_array
-		table.move(outputBuffer, 1, #outputBuffer, _length + 1, _array)
-		_object[_left] = _array
-		_object.outputCount = #outputBuffer
-		_object.message = "Playtest stop signal sent."
-		return _object
-	end
-	local endTest = StudioTestService
-	local endOk = pcall(function()
-		endTest:EndTest("stopped_by_mcp")
-	end)
-	if endOk then
-		return {
-			success = true,
-			output = {},
-			outputCount = 0,
-			message = "Playtest stopped via StudioTestService.",
-		}
-	end
-	return {
-		error = "No MCP-started test is running and direct stop failed. The playtest may have been started manually.",
-	}
-end
-local function getPlaytestOutput(_requestData)
-	if testRunning then
-		rebuildOutputFromHistory()
-	end
-	local _object = {
-		isRunning = testRunning,
-	}
-	local _left = "output"
-	local _array = {}
-	local _length = #_array
-	table.move(outputBuffer, 1, #outputBuffer, _length + 1, _array)
-	_object[_left] = _array
-	_object.outputCount = #outputBuffer
-	_object.testResult = if testResult ~= nil then tostring(testResult) else nil
-	_object.testError = testError
-	return _object
 end
 local function characterNavigation(requestData)
 	if not testRunning then
@@ -5041,8 +5015,6 @@ local function characterNavigation(requestData)
 end
 return {
 	startPlaytest = startPlaytest,
-	stopPlaytest = stopPlaytest,
-	getPlaytestOutput = getPlaytestOutput,
 	characterNavigation = characterNavigation,
 }
 ]]></string>

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -3002,6 +3002,7 @@ local _binding = Utils
 local getInstancePath = _binding.getInstancePath
 local getInstanceByPath = _binding.getInstanceByPath
 local readScriptSource = _binding.readScriptSource
+local forEachDescendant = _binding.forEachDescendant
 local function getFileTree(requestData)
 	local _condition = (requestData.path)
 	if _condition == nil then
@@ -3060,7 +3061,7 @@ local function searchFiles(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3087,11 +3088,7 @@ local function searchFiles(requestData)
 			end
 			table.insert(results, entry)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3167,7 +3164,7 @@ local function searchObjects(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local match = false
 		if searchType == "name" then
 			local _exp = string.lower(instance.Name)
@@ -3198,11 +3195,7 @@ local function searchObjects(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		results = results,
 		query = query,
@@ -3373,7 +3366,7 @@ local function searchByProperty(requestData)
 		}
 	end
 	local results = {}
-	local function searchRecursive(instance)
+	forEachDescendant(game, function(instance)
 		local success, value = pcall(function()
 			return tostring(instance[propertyName])
 		end)
@@ -3392,11 +3385,7 @@ local function searchByProperty(requestData)
 			}
 			table.insert(results, _arg0)
 		end
-		for _, child in instance:GetChildren() do
-			searchRecursive(child)
-		end
-	end
-	searchRecursive(game)
+	end)
 	return {
 		propertyName = propertyName,
 		propertyValue = propertyValue,
@@ -4736,6 +4725,64 @@ local testResult
 local testError
 local stopListenerScript
 local navResultCallback
+-- Marker for the playtest's start time so backfillFromHistory can filter the
+-- LogService history to entries produced during this playtest.
+local playtestStartedAt = 0
+-- LogService.MessageOut connections established in Edit-mode plugin context
+-- don't reliably fire for playtest server output in current Roblox builds — the
+-- Studio DataModel swap on entering play orphans pre-play connections, leaving
+-- `outputBuffer` empty even when the playtest writes plenty of output.
+--
+-- LogService.GetLogHistory(), in contrast, returns the unified output panel
+-- history including playtest entries. Polling it on every getPlaytestOutput
+-- call and on stop_playtest backfills anything MessageOut missed, while keeping
+-- the live MessageOut hookup so non-broken Studio builds still see real-time
+-- updates without doing the extra work.
+local function backfillFromHistory()
+	local ok, history = pcall(function()
+		return game:GetService("LogService"):GetLogHistory()
+	end)
+	if not ok then
+		return nil
+	end
+	local seen = {}
+	for _, entry in outputBuffer do
+		local _arg0 = `{entry.timestamp}|{entry.message}`
+		seen[_arg0] = true
+	end
+	for _, entry in history do
+		if entry.timestamp < playtestStartedAt then
+			continue
+		end
+		local message = entry.message
+		if message == STOP_SIGNAL then
+			continue
+		end
+		local _arg1 = #NAV_SIGNAL
+		if string.sub(message, 1, _arg1) == NAV_SIGNAL then
+			continue
+		end
+		local _arg1_1 = #NAV_RESULT + 1
+		if string.sub(message, 1, _arg1_1) == `{NAV_RESULT}:` then
+			continue
+		end
+		local key = `{entry.timestamp}|{message}`
+		if seen[key] ~= nil then
+			continue
+		end
+		seen[key] = true
+		local _outputBuffer = outputBuffer
+		local _arg0 = {
+			message = message,
+			messageType = tostring(entry.messageType),
+			timestamp = entry.timestamp,
+		}
+		table.insert(_outputBuffer, _arg0)
+	end
+	table.sort(outputBuffer, function(a, b)
+		return a.timestamp < b.timestamp
+	end)
+end
 local function buildCommandListenerSource()
 	return `local LogService = game:GetService("LogService")\
 local StudioTestService = game:GetService("StudioTestService")\
@@ -4844,6 +4891,7 @@ local function startPlaytest(requestData)
 	outputBuffer = {}
 	testResult = nil
 	testError = nil
+	playtestStartedAt = tick()
 	cleanupStopListener()
 	logConnection = LogService.MessageOut:Connect(function(message, messageType)
 		if message == STOP_SIGNAL then
@@ -4899,6 +4947,9 @@ local function startPlaytest(requestData)
 			logConnection:Disconnect()
 			logConnection = nil
 		end
+		-- Final backfill so stop_playtest and any post-play getPlaytestOutput call
+		-- see the full playtest log even if the live MessageOut hookup didn't fire.
+		backfillFromHistory()
 		testRunning = false
 		cleanupStopListener()
 	end)
@@ -4910,6 +4961,10 @@ local function startPlaytest(requestData)
 end
 local function stopPlaytest(_requestData)
 	if testRunning then
+		-- Snapshot LogService history before signalling stop so the response
+		-- already contains the playtest output even if the spawned task hasn't
+		-- returned from ExecutePlayModeAsync yet.
+		backfillFromHistory()
 		warn(STOP_SIGNAL)
 		local _object = {
 			success = true,
@@ -4940,6 +4995,11 @@ local function stopPlaytest(_requestData)
 	}
 end
 local function getPlaytestOutput(_requestData)
+	-- Pull the latest LogService history into outputBuffer on every poll —
+	-- MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
+	if testRunning then
+		backfillFromHistory()
+	end
 	local _object = {
 		isRunning = testRunning,
 	}
@@ -6344,6 +6404,12 @@ local function evaluateFormula(formula, variables, instance, index)
 		return index, "Complex formulas not supported - using index value"
 	end
 end
+local function forEachDescendant(root, visit)
+	visit(root)
+	for _, child in root:GetChildren() do
+		forEachDescendant(child, visit)
+	end
+end
 local function compareVersions(v1, v2)
 	local function parseVersion(v)
 		local parts = {}
@@ -6401,6 +6467,7 @@ return {
 	convertPropertyValue = convertPropertyValue,
 	evaluateFormula = evaluateFormula,
 	compareVersions = compareVersions,
+	forEachDescendant = forEachDescendant,
 }
 ]]></string>
         </Properties>

--- a/studio-plugin/MCPPlugin.rbxmx
+++ b/studio-plugin/MCPPlugin.rbxmx
@@ -4725,31 +4725,19 @@ local testResult
 local testError
 local stopListenerScript
 local navResultCallback
--- Marker for the playtest's start time so backfillFromHistory can filter the
--- LogService history to entries produced during this playtest.
 local playtestStartedAt = 0
--- LogService.MessageOut connections established in Edit-mode plugin context
--- don't reliably fire for playtest server output in current Roblox builds — the
--- Studio DataModel swap on entering play orphans pre-play connections, leaving
--- `outputBuffer` empty even when the playtest writes plenty of output.
---
--- LogService.GetLogHistory(), in contrast, returns the unified output panel
--- history including playtest entries. Polling it on every getPlaytestOutput
--- call and on stop_playtest backfills anything MessageOut missed, while keeping
--- the live MessageOut hookup so non-broken Studio builds still see real-time
--- updates without doing the extra work.
-local function backfillFromHistory()
+-- MessageOut from the Edit-mode plugin context does not see playtest server
+-- output after the Studio DataModel swap, so we rebuild outputBuffer from
+-- LogService.GetLogHistory() on every poll. History is the single source of
+-- truth; the live MessageOut connection is kept only to route NAV results.
+local function rebuildOutputFromHistory()
 	local ok, history = pcall(function()
 		return game:GetService("LogService"):GetLogHistory()
 	end)
 	if not ok then
 		return nil
 	end
-	local seen = {}
-	for _, entry in outputBuffer do
-		local _arg0 = `{entry.timestamp}|{entry.message}`
-		seen[_arg0] = true
-	end
+	local entries = {}
 	for _, entry in history do
 		if entry.timestamp < playtestStartedAt then
 			continue
@@ -4766,22 +4754,14 @@ local function backfillFromHistory()
 		if string.sub(message, 1, _arg1_1) == `{NAV_RESULT}:` then
 			continue
 		end
-		local key = `{entry.timestamp}|{message}`
-		if seen[key] ~= nil then
-			continue
-		end
-		seen[key] = true
-		local _outputBuffer = outputBuffer
 		local _arg0 = {
 			message = message,
 			messageType = tostring(entry.messageType),
 			timestamp = entry.timestamp,
 		}
-		table.insert(_outputBuffer, _arg0)
+		table.insert(entries, _arg0)
 	end
-	table.sort(outputBuffer, function(a, b)
-		return a.timestamp < b.timestamp
-	end)
+	outputBuffer = entries
 end
 local function buildCommandListenerSource()
 	return `local LogService = game:GetService("LogService")\
@@ -4893,33 +4873,19 @@ local function startPlaytest(requestData)
 	testError = nil
 	playtestStartedAt = tick()
 	cleanupStopListener()
-	logConnection = LogService.MessageOut:Connect(function(message, messageType)
-		if message == STOP_SIGNAL then
-			return nil
-		end
+	logConnection = LogService.MessageOut:Connect(function(message)
 		local _message = message
-		local _arg1 = #NAV_SIGNAL
-		if string.sub(_message, 1, _arg1) == NAV_SIGNAL then
-			return nil
+		local _arg1 = #NAV_RESULT + 1
+		local _condition = string.sub(_message, 1, _arg1) == `{NAV_RESULT}:`
+		if _condition then
+			_condition = navResultCallback
 		end
-		local _message_1 = message
-		local _arg1_1 = #NAV_RESULT + 1
-		if string.sub(_message_1, 1, _arg1_1) == `{NAV_RESULT}:` then
-			if navResultCallback then
-				local _fn = navResultCallback
-				local _message_2 = message
-				local _arg0 = #NAV_RESULT + 2
-				_fn(string.sub(_message_2, _arg0))
-			end
-			return nil
+		if _condition then
+			local _fn = navResultCallback
+			local _message_1 = message
+			local _arg0 = #NAV_RESULT + 2
+			_fn(string.sub(_message_1, _arg0))
 		end
-		local _outputBuffer = outputBuffer
-		local _arg0 = {
-			message = message,
-			messageType = messageType.Name,
-			timestamp = tick(),
-		}
-		table.insert(_outputBuffer, _arg0)
 	end)
 	local injected, injErr = pcall(function()
 		return injectStopListener()
@@ -4947,9 +4913,7 @@ local function startPlaytest(requestData)
 			logConnection:Disconnect()
 			logConnection = nil
 		end
-		-- Final backfill so stop_playtest and any post-play getPlaytestOutput call
-		-- see the full playtest log even if the live MessageOut hookup didn't fire.
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 		testRunning = false
 		cleanupStopListener()
 	end)
@@ -4961,10 +4925,7 @@ local function startPlaytest(requestData)
 end
 local function stopPlaytest(_requestData)
 	if testRunning then
-		-- Snapshot LogService history before signalling stop so the response
-		-- already contains the playtest output even if the spawned task hasn't
-		-- returned from ExecutePlayModeAsync yet.
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 		warn(STOP_SIGNAL)
 		local _object = {
 			success = true,
@@ -4995,10 +4956,8 @@ local function stopPlaytest(_requestData)
 	}
 end
 local function getPlaytestOutput(_requestData)
-	-- Pull the latest LogService history into outputBuffer on every poll —
-	-- MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
 	if testRunning then
-		backfillFromHistory()
+		rebuildOutputFromHistory()
 	end
 	local _object = {
 		isRunning = testRunning,

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -75,9 +75,6 @@ const routeMap: Record<string, Handler> = {
 	"/api/bulk-set-attributes": MetadataHandlers.bulkSetAttributes,
 
 	"/api/start-playtest": TestHandlers.startPlaytest,
-	"/api/stop-playtest": TestHandlers.stopPlaytest,
-	"/api/end-test": TestHandlers.endTest,
-	"/api/get-playtest-output": TestHandlers.getPlaytestOutput,
 	"/api/character-navigation": TestHandlers.characterNavigation,
 
 	"/api/export-build": BuildHandlers.exportBuild,

--- a/studio-plugin/src/modules/Communication.ts
+++ b/studio-plugin/src/modules/Communication.ts
@@ -76,6 +76,7 @@ const routeMap: Record<string, Handler> = {
 
 	"/api/start-playtest": TestHandlers.startPlaytest,
 	"/api/stop-playtest": TestHandlers.stopPlaytest,
+	"/api/end-test": TestHandlers.endTest,
 	"/api/get-playtest-output": TestHandlers.getPlaytestOutput,
 	"/api/character-navigation": TestHandlers.characterNavigation,
 

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -245,6 +245,14 @@ function getPlaytestOutput(_requestData: Record<string, unknown>) {
 	};
 }
 
+// Must be called on the playtest server role; EndTest errors in Edit context.
+function endTest(_requestData: Record<string, unknown>) {
+	const target = StudioTestService as unknown as Instance & { EndTest(reason: string): void };
+	const [ok, err] = pcall(() => target.EndTest("stopped_by_mcp"));
+	if (ok) return { success: true };
+	return { error: tostring(err) };
+}
+
 function characterNavigation(requestData: Record<string, unknown>) {
 	if (!testRunning) {
 		return { error: "Playtest must be running. Start a playtest in 'play' mode first." };
@@ -294,6 +302,7 @@ function characterNavigation(requestData: Record<string, unknown>) {
 export = {
 	startPlaytest,
 	stopPlaytest,
+	endTest,
 	getPlaytestOutput,
 	characterNavigation,
 };

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -1,63 +1,84 @@
 import { HttpService, LogService } from "@rbxts/services";
+import State from "../State";
 
 const StudioTestService = game.GetService("StudioTestService");
 const ServerScriptService = game.GetService("ServerScriptService");
 const ScriptEditorService = game.GetService("ScriptEditorService");
 
-const STOP_SIGNAL = "__MCP_STOP__";
 const NAV_SIGNAL = "__MCP_NAV__";
 const NAV_RESULT = "__MCP_NAV_RESULT__";
 
-interface OutputEntry {
-	message: string;
-	messageType: string;
-	timestamp: number;
-}
-
 let testRunning = false;
-let outputBuffer: OutputEntry[] = [];
-let logConnection: RBXScriptConnection | undefined;
+let editNavConnection: RBXScriptConnection | undefined;
 let testResult: unknown;
 let testError: string | undefined;
 let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
-let playtestStartedAt = 0;
 
-// MessageOut from the Edit-mode plugin context does not see playtest server
-// output after the Studio DataModel swap, so we rebuild outputBuffer from
-// LogService.GetLogHistory() on every poll. History is the single source of
-// truth; the live MessageOut connection is kept only to route NAV results.
-function rebuildOutputFromHistory(): void {
-	const [ok, history] = pcall(() => game.GetService("LogService").GetLogHistory());
-	if (!ok) return;
-	const entries: OutputEntry[] = [];
-	for (const entry of history) {
-		if (entry.timestamp < playtestStartedAt) continue;
-		const message = entry.message;
-		if (message === STOP_SIGNAL) continue;
-		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) continue;
-		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) continue;
-		entries.push({
-			message,
-			messageType: tostring(entry.messageType),
-			timestamp: entry.timestamp,
-		});
-	}
-	outputBuffer = entries;
-}
-
-function buildCommandListenerSource(): string {
+function buildCommandListenerSource(baseUrl: string): string {
 	return `local LogService = game:GetService("LogService")
 local StudioTestService = game:GetService("StudioTestService")
 local PathfindingService = game:GetService("PathfindingService")
 local Players = game:GetService("Players")
 local HttpService = game:GetService("HttpService")
+local BASE = "${baseUrl}"
 local NAV_SIG = "${NAV_SIGNAL}"
 local NAV_RES = "${NAV_RESULT}"
+local OUTPUT_URL = BASE .. "/playtest/output"
+local COMMAND_URL = BASE .. "/playtest/command"
+
+local pending = {}
+LogService.MessageOut:Connect(function(msg, mt)
+	if string.sub(msg, 1, #NAV_SIG) == NAV_SIG then return end
+	if string.sub(msg, 1, #NAV_RES) == NAV_RES then return end
+	table.insert(pending, {
+		message = msg,
+		messageType = mt.Name,
+		timestamp = tick(),
+	})
+end)
+
+task.spawn(function()
+	while true do
+		task.wait(0.2)
+		if #pending > 0 then
+			local batch = pending
+			pending = {}
+			pcall(function()
+				HttpService:RequestAsync({
+					Url = OUTPUT_URL,
+					Method = "POST",
+					Headers = { ["Content-Type"] = "application/json" },
+					Body = HttpService:JSONEncode({ entries = batch }),
+				})
+			end)
+		end
+	end
+end)
+
+task.spawn(function()
+	while true do
+		task.wait(0.5)
+		local ok, response = pcall(function()
+			return HttpService:RequestAsync({
+				Url = COMMAND_URL,
+				Method = "GET",
+			})
+		end)
+		if ok and response.Success and response.Body then
+			local parsed
+			local decodeOk
+			decodeOk, parsed = pcall(function() return HttpService:JSONDecode(response.Body) end)
+			if decodeOk and parsed and parsed.stop then
+				pcall(function() StudioTestService:EndTest("stopped_by_mcp") end)
+				return
+			end
+		end
+	end
+end)
+
 LogService.MessageOut:Connect(function(msg)
-	if msg == "${STOP_SIGNAL}" then
-		pcall(function() StudioTestService:EndTest("stopped_by_mcp") end)
-	elseif string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then
+	if string.sub(msg, 1, #NAV_SIG + 1) == NAV_SIG .. ":" then
 		local json = string.sub(msg, #NAV_SIG + 2)
 		task.spawn(function()
 			local ok, d = pcall(function() return HttpService:JSONDecode(json) end)
@@ -115,12 +136,12 @@ LogService.MessageOut:Connect(function(msg)
 end)`;
 }
 
-function injectStopListener() {
+function injectStopListener(baseUrl: string) {
 	const listener = new Instance("Script");
 	listener.Name = "__MCP_CommandListener";
 	listener.Parent = ServerScriptService;
 
-	const source = buildCommandListenerSource();
+	const source = buildCommandListenerSource(baseUrl);
 	const [seOk] = pcall(() => {
 		ScriptEditorService.UpdateSourceAsync(listener, () => source);
 	});
@@ -138,6 +159,17 @@ function cleanupStopListener() {
 	}
 }
 
+function notifyPlaytestEnded(baseUrl: string) {
+	pcall(() => {
+		HttpService.RequestAsync({
+			Url: `${baseUrl}/playtest/end`,
+			Method: "POST",
+			Headers: { ["Content-Type"]: "application/json" },
+			Body: "{}",
+		});
+	});
+}
+
 function startPlaytest(requestData: Record<string, unknown>) {
 	const mode = requestData.mode as string | undefined;
 	const numPlayers = requestData.numPlayers as number | undefined;
@@ -150,23 +182,24 @@ function startPlaytest(requestData: Record<string, unknown>) {
 		return { error: "A test is already running" };
 	}
 
+	const conn = State.getActiveConnection();
+	const baseUrl = conn.serverUrl;
+
 	testRunning = true;
-	outputBuffer = [];
 	testResult = undefined;
 	testError = undefined;
-	playtestStartedAt = tick();
 
 	cleanupStopListener();
 
-	logConnection = LogService.MessageOut.Connect((message) => {
+	editNavConnection = LogService.MessageOut.Connect((message) => {
 		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:` && navResultCallback) {
 			navResultCallback(message.sub(NAV_RESULT.size() + 2));
 		}
 	});
 
-	const [injected, injErr] = pcall(() => injectStopListener());
+	const [injected, injErr] = pcall(() => injectStopListener(baseUrl));
 	if (!injected) {
-		warn(`[MCP] Failed to inject stop listener: ${injErr}`);
+		warn(`[MCP] Failed to inject playtest listener: ${injErr}`);
 	}
 
 	if (numPlayers !== undefined && mode === "run") {
@@ -188,13 +221,12 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			testError = tostring(result);
 		}
 
-		if (logConnection) {
-			logConnection.Disconnect();
-			logConnection = undefined;
+		if (editNavConnection) {
+			editNavConnection.Disconnect();
+			editNavConnection = undefined;
 		}
-		rebuildOutputFromHistory();
 		testRunning = false;
-
+		notifyPlaytestEnded(baseUrl);
 		cleanupStopListener();
 	});
 
@@ -202,55 +234,6 @@ function startPlaytest(requestData: Record<string, unknown>) {
 		? `Playtest started in ${mode} mode with ${numPlayers} player(s)`
 		: `Playtest started in ${mode} mode`;
 	return { success: true, message: msg };
-}
-
-function stopPlaytest(_requestData: Record<string, unknown>) {
-	if (testRunning) {
-		rebuildOutputFromHistory();
-		warn(STOP_SIGNAL);
-		return {
-			success: true,
-			output: [...outputBuffer],
-			outputCount: outputBuffer.size(),
-			message: "Playtest stop signal sent.",
-		};
-	}
-
-	const endTest = StudioTestService as unknown as Instance & { EndTest(reason: string): void };
-	const [endOk] = pcall(() => {
-		endTest.EndTest("stopped_by_mcp");
-	});
-	if (endOk) {
-		return {
-			success: true,
-			output: [],
-			outputCount: 0,
-			message: "Playtest stopped via StudioTestService.",
-		};
-	}
-
-	return { error: "No MCP-started test is running and direct stop failed. The playtest may have been started manually." };
-}
-
-function getPlaytestOutput(_requestData: Record<string, unknown>) {
-	if (testRunning) {
-		rebuildOutputFromHistory();
-	}
-	return {
-		isRunning: testRunning,
-		output: [...outputBuffer],
-		outputCount: outputBuffer.size(),
-		testResult: testResult !== undefined ? tostring(testResult) : undefined,
-		testError,
-	};
-}
-
-// Must be called on the playtest server role; EndTest errors in Edit context.
-function endTest(_requestData: Record<string, unknown>) {
-	const target = StudioTestService as unknown as Instance & { EndTest(reason: string): void };
-	const [ok, err] = pcall(() => target.EndTest("stopped_by_mcp"));
-	if (ok) return { success: true };
-	return { error: tostring(err) };
 }
 
 function characterNavigation(requestData: Record<string, unknown>) {
@@ -301,8 +284,5 @@ function characterNavigation(requestData: Record<string, unknown>) {
 
 export = {
 	startPlaytest,
-	stopPlaytest,
-	endTest,
-	getPlaytestOutput,
 	characterNavigation,
 };

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -21,6 +21,44 @@ let testResult: unknown;
 let testError: string | undefined;
 let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
+// Marker for the playtest's start time so backfillFromHistory can filter the
+// LogService history to entries produced during this playtest.
+let playtestStartedAt = 0;
+
+// LogService.MessageOut connections established in Edit-mode plugin context
+// don't reliably fire for playtest server output in current Roblox builds — the
+// Studio DataModel swap on entering play orphans pre-play connections, leaving
+// `outputBuffer` empty even when the playtest writes plenty of output.
+//
+// LogService.GetLogHistory(), in contrast, returns the unified output panel
+// history including playtest entries. Polling it on every getPlaytestOutput
+// call and on stop_playtest backfills anything MessageOut missed, while keeping
+// the live MessageOut hookup so non-broken Studio builds still see real-time
+// updates without doing the extra work.
+function backfillFromHistory(): void {
+	const [ok, history] = pcall(() => game.GetService("LogService").GetLogHistory());
+	if (!ok) return;
+	const seen = new Set<string>();
+	for (const entry of outputBuffer) {
+		seen.add(`${entry.timestamp}|${entry.message}`);
+	}
+	for (const entry of history) {
+		if (entry.timestamp < playtestStartedAt) continue;
+		const message = entry.message;
+		if (message === STOP_SIGNAL) continue;
+		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) continue;
+		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) continue;
+		const key = `${entry.timestamp}|${message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		outputBuffer.push({
+			message,
+			messageType: tostring(entry.messageType),
+			timestamp: entry.timestamp,
+		});
+	}
+	outputBuffer.sort((a, b) => a.timestamp < b.timestamp);
+}
 
 function buildCommandListenerSource(): string {
 	return `local LogService = game:GetService("LogService")
@@ -130,6 +168,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 	outputBuffer = [];
 	testResult = undefined;
 	testError = undefined;
+	playtestStartedAt = tick();
 
 	cleanupStopListener();
 
@@ -177,6 +216,9 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			logConnection.Disconnect();
 			logConnection = undefined;
 		}
+		// Final backfill so stop_playtest and any post-play getPlaytestOutput call
+		// see the full playtest log even if the live MessageOut hookup didn't fire.
+		backfillFromHistory();
 		testRunning = false;
 
 		cleanupStopListener();
@@ -190,6 +232,10 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 function stopPlaytest(_requestData: Record<string, unknown>) {
 	if (testRunning) {
+		// Snapshot LogService history before signalling stop so the response
+		// already contains the playtest output even if the spawned task hasn't
+		// returned from ExecutePlayModeAsync yet.
+		backfillFromHistory();
 		warn(STOP_SIGNAL);
 		return {
 			success: true,
@@ -216,6 +262,11 @@ function stopPlaytest(_requestData: Record<string, unknown>) {
 }
 
 function getPlaytestOutput(_requestData: Record<string, unknown>) {
+	// Pull the latest LogService history into outputBuffer on every poll —
+	// MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
+	if (testRunning) {
+		backfillFromHistory();
+	}
 	return {
 		isRunning: testRunning,
 		output: [...outputBuffer],

--- a/studio-plugin/src/modules/handlers/TestHandlers.ts
+++ b/studio-plugin/src/modules/handlers/TestHandlers.ts
@@ -21,43 +21,29 @@ let testResult: unknown;
 let testError: string | undefined;
 let stopListenerScript: Script | undefined;
 let navResultCallback: ((json: string) => void) | undefined;
-// Marker for the playtest's start time so backfillFromHistory can filter the
-// LogService history to entries produced during this playtest.
 let playtestStartedAt = 0;
 
-// LogService.MessageOut connections established in Edit-mode plugin context
-// don't reliably fire for playtest server output in current Roblox builds — the
-// Studio DataModel swap on entering play orphans pre-play connections, leaving
-// `outputBuffer` empty even when the playtest writes plenty of output.
-//
-// LogService.GetLogHistory(), in contrast, returns the unified output panel
-// history including playtest entries. Polling it on every getPlaytestOutput
-// call and on stop_playtest backfills anything MessageOut missed, while keeping
-// the live MessageOut hookup so non-broken Studio builds still see real-time
-// updates without doing the extra work.
-function backfillFromHistory(): void {
+// MessageOut from the Edit-mode plugin context does not see playtest server
+// output after the Studio DataModel swap, so we rebuild outputBuffer from
+// LogService.GetLogHistory() on every poll. History is the single source of
+// truth; the live MessageOut connection is kept only to route NAV results.
+function rebuildOutputFromHistory(): void {
 	const [ok, history] = pcall(() => game.GetService("LogService").GetLogHistory());
 	if (!ok) return;
-	const seen = new Set<string>();
-	for (const entry of outputBuffer) {
-		seen.add(`${entry.timestamp}|${entry.message}`);
-	}
+	const entries: OutputEntry[] = [];
 	for (const entry of history) {
 		if (entry.timestamp < playtestStartedAt) continue;
 		const message = entry.message;
 		if (message === STOP_SIGNAL) continue;
 		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) continue;
 		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) continue;
-		const key = `${entry.timestamp}|${message}`;
-		if (seen.has(key)) continue;
-		seen.add(key);
-		outputBuffer.push({
+		entries.push({
 			message,
 			messageType: tostring(entry.messageType),
 			timestamp: entry.timestamp,
 		});
 	}
-	outputBuffer.sort((a, b) => a.timestamp < b.timestamp);
+	outputBuffer = entries;
 }
 
 function buildCommandListenerSource(): string {
@@ -172,20 +158,10 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 	cleanupStopListener();
 
-	logConnection = LogService.MessageOut.Connect((message, messageType) => {
-		if (message === STOP_SIGNAL) return;
-		if (message.sub(1, NAV_SIGNAL.size()) === NAV_SIGNAL) return;
-		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:`) {
-			if (navResultCallback) {
-				navResultCallback(message.sub(NAV_RESULT.size() + 2));
-			}
-			return;
+	logConnection = LogService.MessageOut.Connect((message) => {
+		if (message.sub(1, NAV_RESULT.size() + 1) === `${NAV_RESULT}:` && navResultCallback) {
+			navResultCallback(message.sub(NAV_RESULT.size() + 2));
 		}
-		outputBuffer.push({
-			message,
-			messageType: messageType.Name,
-			timestamp: tick(),
-		});
 	});
 
 	const [injected, injErr] = pcall(() => injectStopListener());
@@ -216,9 +192,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 			logConnection.Disconnect();
 			logConnection = undefined;
 		}
-		// Final backfill so stop_playtest and any post-play getPlaytestOutput call
-		// see the full playtest log even if the live MessageOut hookup didn't fire.
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 		testRunning = false;
 
 		cleanupStopListener();
@@ -232,10 +206,7 @@ function startPlaytest(requestData: Record<string, unknown>) {
 
 function stopPlaytest(_requestData: Record<string, unknown>) {
 	if (testRunning) {
-		// Snapshot LogService history before signalling stop so the response
-		// already contains the playtest output even if the spawned task hasn't
-		// returned from ExecutePlayModeAsync yet.
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 		warn(STOP_SIGNAL);
 		return {
 			success: true,
@@ -262,10 +233,8 @@ function stopPlaytest(_requestData: Record<string, unknown>) {
 }
 
 function getPlaytestOutput(_requestData: Record<string, unknown>) {
-	// Pull the latest LogService history into outputBuffer on every poll —
-	// MessageOut alone is unreliable across Studio's Edit↔Play DataModel swap.
 	if (testRunning) {
-		backfillFromHistory();
+		rebuildOutputFromHistory();
 	}
 	return {
 		isRunning: testRunning,


### PR DESCRIPTION
Fixes #71.

## Problem

`get_playtest_output` and `stop_playtest` both fail on current Studio builds:

- `outputCount: 0` even when the playtest server produces print/warn/error.
- `stop_playtest` returns success but the playtest keeps running. User has to click Stop in Studio.

Root cause is the Studio Edit ↔ Play DataModel split. The plugin runs in Edit context only and the playtest server is a separate DataModel. The original `LogService.MessageOut:Connect(...)` happens in Edit context, so it never sees playtest server output. `StudioTestService:EndTest` errors with `"can only be called from the server DataModel of a running Studio play session"` when called from the plugin. `warn(STOP_SIGNAL)` from Edit also does not reach the injected listener's `LogService.MessageOut` in playtest server, because the two DataModels have separate `LogService` instances.

## Fix

The injected `__MCP_CommandListener` script already runs in the playtest server DataModel. It now does the bridging instead of relying on cross-DataModel signal propagation:

1. Hooks `LogService.MessageOut` server-side, buffers entries, batch-POSTs them every 200 ms to `http://localhost:<port>/playtest/output` on the MCP HTTP server.
2. Polls `http://localhost:<port>/playtest/command` every 500 ms. When the response says `{stop: true}` it calls `StudioTestService:EndTest("stopped_by_mcp")` from playtest server context, which is the only context where that call is allowed.

The MCP HTTP server (`packages/core`) holds the per-session buffer and stop flag in `BridgeService`. `stop_playtest` sets the flag and reads the buffer directly; `get_playtest_output` reads the buffer directly. No plugin round-trip is needed for either tool, so they keep working even when the Edit-side plugin is busy or disconnected.

The base URL the listener uses is read from `State.getActiveConnection().serverUrl` at injection time, so the listener targets whichever port the plugin is currently connected to.

## What changed

- `packages/core/src/bridge-service.ts`: adds `resetPlaytest`, `endPlaytest`, `pushPlaytestOutput`, `getPlaytestBuffer`, `requestPlaytestStop`, `isPlaytestStopRequested`, `isPlaytestActive`.
- `packages/core/src/http-server.ts`: adds `POST /playtest/output`, `GET /playtest/command`, `POST /playtest/end`.
- `packages/core/src/tools/index.ts`: `startPlaytest` resets server state; `stopPlaytest` and `getPlaytestOutput` read from `BridgeService` directly.
- `studio-plugin/src/modules/handlers/TestHandlers.ts`: injected listener does the new MessageOut hook + push loop + command poll. Plugin-side `startPlaytest` injects this listener, runs `ExecutePlayModeAsync`, and POSTs `/playtest/end` when the test ends so `isPlaytestActive` flips back to false.
- `studio-plugin/src/modules/Communication.ts`: removes the now-dead `/api/stop-playtest`, `/api/get-playtest-output`, `/api/end-test` routes.
- `studio-plugin/MCPPlugin.rbxmx`: regenerated.

## Verified

In a project with HTTP requests enabled, this flow now works end to end:

1. `start_playtest { mode: "play" }` -> plugin injects listener + `ExecutePlayModeAsync`.
2. `get_playtest_output` returns the live buffer with real server entries (boot lines, system prints, `print`, `warn`, `error`, ProfileStore init, etc.) tagged with their `messageType`.
3. `stop_playtest` flips the stop flag, the listener picks it up on its next 500 ms poll, calls `EndTest`, the playtest actually ends, and `isRunning` reads `false`.

Earlier commits on this branch (`679c812`, `aecee0d`, `886f944`) are iteration noise from approaches that did not work for the reasons described under Problem. Safe to squash on merge.

## Notes

- The listener uses `HttpService:RequestAsync`, which requires HTTP requests to be enabled in the game (Game Settings > Security > Allow HTTP Requests). The README already documents this requirement for the plugin in general.
- `LogService.MessageOut` is hooked once for output capture and once for NAV-result routing. NAV-result messages and the legacy in-band signal strings are filtered out of the captured buffer.
- If a playtest produces output very fast (>several hundred entries per 200 ms), entries between flushes batch into one POST. Order is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken playtest output capture and stop by moving both into the playtest server and bridging via HTTP. `get_playtest_output` now returns real server logs, and `stop_playtest` reliably ends the session.

- **Bug Fixes**
  - Injected `__MCP_CommandListener` runs in the playtest server: batches `LogService.MessageOut` to `POST /playtest/output` (200ms) and polls `GET /playtest/command` (500ms) to call `StudioTestService:EndTest`.
  - Added HTTP endpoints in `packages/core/src/http-server.ts`: `POST /playtest/output`, `GET /playtest/command`, `POST /playtest/end`; `BridgeService` tracks playtest state and buffer (`resetPlaytest`, `endPlaytest`, `pushPlaytestOutput`, `getPlaytestBuffer`, `requestPlaytestStop`, checks).
  - Updated tools in `packages/core/src/tools/index.ts`: `startPlaytest` resets state after a successful start; `getPlaytestOutput` and `stopPlaytest` read/update `BridgeService` directly and return `isRunning`, `output`, `outputCount`.
  - Plugin cleanup: removed edit routes `/api/stop-playtest` and `/api/get-playtest-output`; listener targets `State.getActiveConnection().serverUrl` and posts `/playtest/end` when the test finishes; NAV messages are filtered from captured output.

- **Migration**
  - Ensure “Allow HTTP Requests” is enabled in the game settings. No API changes for existing tools.

<sup>Written for commit a1b41d83ca607e1445554539c32ad8b607f12f4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/boshyxd/robloxstudio-mcp/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints and UI hooks to stream playtest output and to request playtest stop from the server.
  * Playtests now return buffered output and a finalization notification when they end.

* **Refactor**
  * Centralized and simplified playtest state and output buffering across the platform.
  * Plugin traversal and search logic optimized for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
